### PR TITLE
chore: fix directory typo and add validation (v1.0.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations for enhanced software development workflow",
   "author": {
     "name": "Ladislav Martincik",

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -1,0 +1,32 @@
+name: Validate Plugin Schema
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - '.claude-plugin/plugin.json'
+      - '.github/workflows/validate-plugin.yml'
+  pull_request:
+    branches: [main, master]
+    paths:
+      - '.claude-plugin/plugin.json'
+      - '.github/workflows/validate-plugin.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Validate plugin.json schema
+        run: bun run validate

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Bun
+bun.lockb
+
 # Logs
 logs/
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the SDLC Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-10-30
+
+### Fixed
+- Fixed directory typo: renamed `.cluade-plugin` to `.claude-plugin`
+
+### Added
+- GitHub Actions workflow for automated plugin schema validation
+- Validation script using Zod for schema enforcement
+- CI/CD pipeline to validate plugin.json on PRs and pushes
+
 ## [1.0.0] - 2025-10-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sdlc-plugin",
+  "version": "1.0.1",
+  "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "validate": "bun run scripts/validate-plugin.ts"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "zod": "^3.23.8"
+  }
+}

--- a/scripts/validate-plugin.ts
+++ b/scripts/validate-plugin.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env bun
+import { z } from 'zod';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+const PluginManifestSchema = z.object({
+  name: z.string(),
+  version: z.string().regex(/^\d+\.\d+\.\d+$/, 'Version must follow semver format'),
+  description: z.string(),
+  author: z.object({
+    name: z.string(),
+    email: z.string().email().optional(),
+    url: z.string().url().optional(),
+  }),
+  homepage: z.string().url().optional(),
+  repository: z.string().url().optional(),
+  license: z.string().optional(),
+  keywords: z.array(z.string()).optional(),
+  engines: z.object({
+    claude: z.string().optional(),
+    node: z.string().optional(),
+  }).optional(),
+});
+
+async function validatePlugin() {
+  const pluginJsonPath = join(process.cwd(), '.claude-plugin/plugin.json');
+
+  try {
+    const content = await readFile(pluginJsonPath, 'utf-8');
+    const json = JSON.parse(content);
+
+    const result = PluginManifestSchema.safeParse(json);
+
+    if (!result.success) {
+      console.error('❌ Plugin validation failed:');
+      console.error(JSON.stringify(result.error.format(), null, 2));
+      process.exit(1);
+    }
+
+    console.log(`✅ ${result.data.name} v${result.data.version} is valid`);
+
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error('❌ Error reading plugin.json:', error.message);
+    }
+    process.exit(1);
+  }
+}
+
+validatePlugin();


### PR DESCRIPTION
## Summary
- Fixed directory typo: renamed `.cluade-plugin` to `.claude-plugin`
- Added CI/CD pipeline with GitHub Actions for automated plugin schema validation
- Bumped version to 1.0.1

## Changes
- Renamed `.cluade-plugin/` → `.claude-plugin/` (correct naming convention)
- Added GitHub Actions workflow for automated plugin.json validation
- Added validation script using Zod for schema enforcement
- Updated CHANGELOG.md with v1.0.1 notes
- Added .gitignore for bun.lockb

## Testing
- ✅ Local validation passes: `bun run validate`
- ✅ Plugin.json follows correct schema
- ✅ GitHub Actions will validate on future PRs

## Files Changed
- `.cluade-plugin/plugin.json` → `.claude-plugin/plugin.json` (renamed)
- `.github/workflows/validate-plugin.yml` - CI/CD workflow
- `scripts/validate-plugin.ts` - Zod validation logic
- `CHANGELOG.md` - Version 1.0.1 notes
- `package.json` - Validation scripts
- `.gitignore` - Updated

This ensures the plugin follows the correct directory naming convention per Claude Code docs.