### PR TITLE
fix: remove invalid engines field from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,9 +18,5 @@
     "codebase-analysis",
     "ai-agents",
     "claude-code"
-  ],
-  "engines": {
-    "claude": ">=1.0.0",
-    "node": ">=18.0.0"
-  }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed directory typo: renamed `.cluade-plugin` to `.claude-plugin`
+- Removed invalid `engines` field from plugin.json (not supported by Claude Code schema)
 
 ### Added
 - GitHub Actions workflow for automated plugin schema validation
-- Validation script using Zod for schema enforcement
+- Validation script using Zod for schema enforcement with proper field validation
 - CI/CD pipeline to validate plugin.json on PRs and pushes
 
 ## [1.0.0] - 2025-10-30

--- a/scripts/validate-plugin.ts
+++ b/scripts/validate-plugin.ts
@@ -16,10 +16,10 @@ const PluginManifestSchema = z.object({
   repository: z.string().url().optional(),
   license: z.string().optional(),
   keywords: z.array(z.string()).optional(),
-  engines: z.object({
-    claude: z.string().optional(),
-    node: z.string().optional(),
-  }).optional(),
+  commands: z.union([z.string(), z.array(z.string())]).optional(),
+  agents: z.union([z.string(), z.array(z.string())]).optional(),
+  hooks: z.union([z.string(), z.record(z.any())]).optional(),
+  mcpServers: z.union([z.string(), z.record(z.any())]).optional(),
 });
 
 async function validatePlugin() {


### PR DESCRIPTION
## Summary
- Removed unsupported `engines` field from plugin.json (not in Claude Code schema)
- Updated validation script to match official Claude Code schema
- Added support for valid optional fields: commands, agents, hooks, mcpServers

## Problem
The plugin was failing to install with error:
```
Plugin has an invalid manifest file. Validation errors: Unrecognized key(s) in object: 'engines'
```

## Solution
The `engines` field is not part of the official Claude Code plugin.json schema. Removed it and updated our validation script to match the actual schema from the docs.

## Changes
- `.claude-plugin/plugin.json` - Removed `engines` object
- `scripts/validate-plugin.ts` - Updated schema to match official spec
- `CHANGELOG.md` - Documented the fix

## Testing
- ✅ Local validation passes: `bun run validate`
- ✅ Plugin.json now matches official schema
- ✅ Should install without errors

Fixes the installation validation error.