### PR TITLE
feat: add self-reflection, session naming, and ultrathink to SDLC commands

### DIFF
--- a/commands/implement.md
+++ b/commands/implement.md
@@ -2,6 +2,13 @@
 
 Follow the `Instructions` to implement the `Plan` with `Feedback loops` then `Report` the completed work.
 
+## Session Naming
+
+Before starting, rename this session for clarity:
+- If `$ARGUMENTS` is an issue number: `/rename "Implement: #$ARGUMENTS"`
+- If `$ARGUMENTS` is a plan file: `/rename "Implement: {plan-name}"`
+- Otherwise infer from current branch or plan context
+
 ## Instructions
 
 ### 1. Check if we're on work branch not main
@@ -29,7 +36,7 @@ Follow the `Instructions` to implement the `Plan` with `Feedback loops` then `Re
 - Check Issue body for existing checkmarks (progress tracking)
 - Read all files mentioned in the plan
 - **Read files fully** - never use limit/offset parameters, you need complete context
-- Think deeply about how the pieces fit together
+- Ultrathink about how the pieces fit together
 - Create a todo list to track your progress
 - Start implementing if you understand what needs to be done
 
@@ -47,7 +54,7 @@ When things don't match the plan exactly, think about why and communicate clearl
 The plan is your guide, but your judgment matters too.
 
 If you encounter a mismatch:
-- STOP and think deeply about why the plan can't be followed
+- STOP and ultrathink about why the plan can't be followed
 - Present the issue clearly:
   ```text
   Issue in Phase [N]:

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -2,6 +2,12 @@
 
 Create a new plan in plans/*.md to resolve the `Plan` using the exact specified markdown `Plan Format`. Follow the `Instructions` to create the plan use the `Relevant Files` to focus on the right files.
 
+## Session Naming
+
+Before starting, rename this session for clarity:
+- If `$ARGUMENTS` provided: `/rename "Plan: $ARGUMENTS"`
+- Otherwise infer from context and run `/rename "Plan: {feature-name}"`
+
 ## Instructions
 
 - IMPORTANT: You're writing a plan to resolve a task based on the `Plan` that will add value to the application.
@@ -11,7 +17,7 @@ Create a new plan in plans/*.md to resolve the `Plan` using the exact specified 
 - Use the plan format below to create the plan.
 - Research the codebase to understand the task, reproduce it, and put together a plan to fix it.
 - IMPORTANT: Replace every <placeholder> in the `Plan Format` with the requested value. Add as much detail as needed to fix the task.
-- Use your reasoning model: THINK HARD about the task, its root cause, and the steps to fix it properly.
+- Use your reasoning model: ultrathink about the task, its root cause, and the steps to fix it properly.
 - IMPORTANT: For all phases that have high complexity must be split into sub-tasks that are low or medium complexity. High complexity tasks will have more tasks to work on, but not more than 5.
 - IMPORTANT: Be surgical with your fix, solve the task at hand and don't fall off track.
 - IMPORTANT: We want the minimal number of changes that will fix and address the task.

--- a/commands/research.md
+++ b/commands/research.md
@@ -2,6 +2,12 @@
 
 Research and analyze the `Idea` within the context of the current codebase. Follow the `Instructions` to prepare a comprehensive discussion framework.
 
+## Session Naming
+
+Before starting, rename this session for clarity:
+- If `$ARGUMENTS` provided: `/rename "Research: $ARGUMENTS"`
+- Otherwise wait for the research topic, then run `/rename "Research: {topic}"`
+
 ## CRITICAL: YOUR ONLY JOB IS TO DOCUMENT AND EXPLAIN THE CODEBASE AS IT EXISTS TODAY
 - DO NOT suggest improvements or changes unless the user explicitly asks for them
 - DO NOT perform root cause analysis unless the user explicitly asks for them


### PR DESCRIPTION
## Summary

- Add self-reflection guidance during implementation phase
- Add session naming (`/rename`) instructions to research, plan, and implement commands
- Add "ultrathink" keyword to plan and implement commands for deeper reasoning

## Changes

| File | Changes |
|------|---------|
| `commands/implement.md` | Self-reflection, session naming, ultrathink |
| `commands/plan.md` | Session naming, ultrathink |
| `commands/research.md` | Session naming |
| `plugin.json` | Version bump to 1.3.2 |

## Test plan

- [x] Plugin validation passes (`bun run validate`)
- [ ] Test `/research`, `/plan`, `/implement` commands trigger session renaming
- [ ] Test ultrathink triggers deeper reasoning in plan/implement