### PR TITLE
feat: version synchronization enforcement (v1.4.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations for enhanced software development workflow",
   "author": {
     "name": "Ladislav Martincik",

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -1,16 +1,10 @@
-name: Validate Plugin Schema
+name: Validate Plugin
 
 on:
   push:
     branches: [main, master]
-    paths:
-      - '.claude-plugin/plugin.json'
-      - '.github/workflows/validate-plugin.yml'
   pull_request:
     branches: [main, master]
-    paths:
-      - '.claude-plugin/plugin.json'
-      - '.github/workflows/validate-plugin.yml'
 
 jobs:
   validate:
@@ -28,5 +22,5 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Validate plugin.json schema
+      - name: Validate plugin (versions, schema, docs)
         run: bun run validate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the SDLC Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2025-12-23
+
+### Added
+- Version synchronization enforcement across package.json, plugin.json, and CHANGELOG.md
+- New `validate-versions.ts` script to check version consistency
+- New `release.ts` script for atomic version bumps across all 3 files
+- New npm scripts: `validate:versions`, `release:patch`, `release:minor`, `release:major`
+- Self-reflection guidance during implementation (from 1.3.2)
+- Session naming and ultrathink to SDLC commands (from 1.3.2)
+
+### Changed
+- CI workflow now triggers on all pushes (removed paths filter) to catch version mismatches
+- `validate-plugin.ts` now checks version synchronization before other validations
+
+### Fixed
+- Version mismatch: CHANGELOG was behind (1.3.0 vs package.json/plugin.json 1.3.2)
+- Gemini CLI hanging on interactive prompts (from 1.3.1)
+
 ## [1.3.0] - 2025-11-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "name": "sdlc-plugin",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations",
   "private": true,
   "type": "module",
   "scripts": {
-    "validate": "bun run scripts/validate-plugin.ts"
+    "validate": "bun run scripts/validate-plugin.ts",
+    "validate:versions": "bun run scripts/validate-versions.ts",
+    "release:patch": "bun run scripts/release.ts patch",
+    "release:minor": "bun run scripts/release.ts minor",
+    "release:major": "bun run scripts/release.ts major"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env bun
+/**
+ * Atomic Version Bump Script
+ *
+ * Updates version in all three files simultaneously:
+ * - package.json
+ * - .claude-plugin/plugin.json
+ * - CHANGELOG.md (adds new entry)
+ *
+ * Usage:
+ *   bun run scripts/release.ts patch   # 1.4.0 → 1.4.1
+ *   bun run scripts/release.ts minor   # 1.4.0 → 1.5.0
+ *   bun run scripts/release.ts major   # 1.4.0 → 2.0.0
+ */
+
+import { readFile, writeFile } from "fs/promises";
+import { join } from "path";
+
+type BumpType = "major" | "minor" | "patch";
+
+function bumpVersion(current: string, type: BumpType): string {
+  const [major, minor, patch] = current.split(".").map(Number);
+  switch (type) {
+    case "major":
+      return `${major + 1}.0.0`;
+    case "minor":
+      return `${major}.${minor + 1}.0`;
+    case "patch":
+      return `${major}.${minor}.${patch + 1}`;
+  }
+}
+
+function formatDate(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+async function release(type: BumpType) {
+  const cwd = process.cwd();
+
+  // 1. Read current version from package.json
+  const pkgPath = join(cwd, "package.json");
+  const pkgContent = await readFile(pkgPath, "utf-8");
+  const pkg = JSON.parse(pkgContent);
+  const currentVersion = pkg.version;
+  const newVersion = bumpVersion(currentVersion, type);
+
+  console.log(`Bumping version: ${currentVersion} → ${newVersion}\n`);
+
+  // 2. Update package.json
+  pkg.version = newVersion;
+  await writeFile(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+  console.log(`✅ Updated package.json`);
+
+  // 3. Update plugin.json
+  const pluginPath = join(cwd, ".claude-plugin/plugin.json");
+  const pluginContent = await readFile(pluginPath, "utf-8");
+  const plugin = JSON.parse(pluginContent);
+  plugin.version = newVersion;
+  await writeFile(pluginPath, JSON.stringify(plugin, null, 2) + "\n");
+  console.log(`✅ Updated .claude-plugin/plugin.json`);
+
+  // 4. Update CHANGELOG.md
+  const changelogPath = join(cwd, "CHANGELOG.md");
+  let changelog = await readFile(changelogPath, "utf-8");
+
+  const newEntry = `## [${newVersion}] - ${formatDate()}\n\n### Changed\n- TODO: Add changes\n\n`;
+
+  // Find the first version header and insert before it
+  const firstVersionMatch = changelog.match(/^## \[\d+\.\d+\.\d+\]/m);
+  if (firstVersionMatch && firstVersionMatch.index !== undefined) {
+    changelog =
+      changelog.slice(0, firstVersionMatch.index) +
+      newEntry +
+      changelog.slice(firstVersionMatch.index);
+  } else {
+    // No existing version, find end of header and append
+    const headerEnd = changelog.indexOf("\n\n") + 2;
+    changelog =
+      changelog.slice(0, headerEnd) + newEntry + changelog.slice(headerEnd);
+  }
+
+  await writeFile(changelogPath, changelog);
+  console.log(`✅ Updated CHANGELOG.md`);
+
+  console.log(`\n🎉 Version ${newVersion} prepared\n`);
+  console.log("Next steps:");
+  console.log("  1. Edit CHANGELOG.md to add actual changes");
+  console.log(`  2. git add -A && git commit -m "chore: release v${newVersion}"`);
+  console.log(`  3. git tag v${newVersion}`);
+  console.log("  4. git push && git push --tags");
+}
+
+// Parse CLI args
+const type = process.argv[2] as BumpType;
+if (!["major", "minor", "patch"].includes(type)) {
+  console.error("Usage: bun run scripts/release.ts <major|minor|patch>");
+  process.exit(1);
+}
+
+release(type);

--- a/scripts/validate-versions.ts
+++ b/scripts/validate-versions.ts
@@ -1,0 +1,130 @@
+#!/usr/bin/env bun
+/**
+ * Version Synchronization Validator
+ *
+ * Ensures version consistency across:
+ * - package.json (version field)
+ * - .claude-plugin/plugin.json (version field)
+ * - CHANGELOG.md (latest ## [X.Y.Z] header)
+ *
+ * Exit codes:
+ *   0 - All versions synchronized
+ *   1 - Version mismatch detected
+ */
+
+import { readFile } from "fs/promises";
+import { join } from "path";
+
+interface VersionInfo {
+  source: string;
+  version: string | null;
+  path: string;
+}
+
+interface ValidationResult {
+  success: boolean;
+  versions: VersionInfo[];
+  mismatchDetails?: string;
+}
+
+async function extractPackageVersion(cwd: string): Promise<VersionInfo> {
+  const path = join(cwd, "package.json");
+  try {
+    const content = await readFile(path, "utf-8");
+    const json = JSON.parse(content);
+    return { source: "package.json", version: json.version || null, path };
+  } catch {
+    return { source: "package.json", version: null, path };
+  }
+}
+
+async function extractPluginVersion(cwd: string): Promise<VersionInfo> {
+  const path = join(cwd, ".claude-plugin/plugin.json");
+  try {
+    const content = await readFile(path, "utf-8");
+    const json = JSON.parse(content);
+    return { source: "plugin.json", version: json.version || null, path };
+  } catch {
+    return { source: "plugin.json", version: null, path };
+  }
+}
+
+async function extractChangelogVersion(cwd: string): Promise<VersionInfo> {
+  const path = join(cwd, "CHANGELOG.md");
+  try {
+    const content = await readFile(path, "utf-8");
+    // Match first occurrence of ## [X.Y.Z] - ignoring [Unreleased]
+    const versionRegex = /^## \[(\d+\.\d+\.\d+)\]/m;
+    const match = content.match(versionRegex);
+    return {
+      source: "CHANGELOG.md",
+      version: match ? match[1] : null,
+      path,
+    };
+  } catch {
+    return { source: "CHANGELOG.md", version: null, path };
+  }
+}
+
+export async function validateVersions(
+  cwd: string = process.cwd()
+): Promise<ValidationResult> {
+  const [pkgVersion, pluginVersion, changelogVersion] = await Promise.all([
+    extractPackageVersion(cwd),
+    extractPluginVersion(cwd),
+    extractChangelogVersion(cwd),
+  ]);
+
+  const versions = [pkgVersion, pluginVersion, changelogVersion];
+  const validVersions = versions.filter((v) => v.version !== null);
+
+  if (validVersions.length === 0) {
+    return {
+      success: false,
+      versions,
+      mismatchDetails: "No version information found in any file",
+    };
+  }
+
+  // Check if all versions match
+  const uniqueVersions = new Set(validVersions.map((v) => v.version));
+
+  if (uniqueVersions.size === 1) {
+    return { success: true, versions };
+  }
+
+  // Build detailed mismatch report
+  const mismatchDetails = versions
+    .map((v) => `  ${v.source.padEnd(14)} ${v.version ?? "(not found)"}`)
+    .join("\n");
+
+  return {
+    success: false,
+    versions,
+    mismatchDetails: `Version mismatch detected:\n${mismatchDetails}`,
+  };
+}
+
+// CLI entry point
+async function main() {
+  const result = await validateVersions();
+
+  if (result.success) {
+    const version = result.versions.find((v) => v.version)?.version;
+    console.log(`✅ All versions synchronized: ${version}`);
+    process.exit(0);
+  } else {
+    console.error("❌ Version synchronization failed!\n");
+    console.error(result.mismatchDetails);
+    console.error("\nAll three files must have the same version:");
+    console.error("  1. package.json (version field)");
+    console.error("  2. .claude-plugin/plugin.json (version field)");
+    console.error("  3. CHANGELOG.md (latest ## [X.Y.Z] header)");
+    process.exit(1);
+  }
+}
+
+// Only run when executed directly, not when imported
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## Summary
- Add version synchronization enforcement across package.json, plugin.json, and CHANGELOG.md
- New scripts: `validate-versions.ts` and `release.ts` for atomic version management
- CI now triggers on all pushes to catch version mismatches
- Fixes existing CHANGELOG mismatch (was at 1.3.0, now synced to 1.4.0)
- Consolidates changes from 1.3.1 and 1.3.2 into CHANGELOG

## Changes
- `scripts/validate-versions.ts` - checks all 3 version sources match
- `scripts/release.ts` - atomic bump command (`bun run release:minor`)
- `scripts/validate-plugin.ts` - now validates versions first
- `.github/workflows/validate-plugin.yml` - removed paths filter
- Version bumped to 1.4.0

## Test plan
- [x] `bun run validate` passes
- [x] All versions synchronized to 1.4.0