### PR TITLE
feat: add /review command for parallel Codex + Gemini code reviews

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations for enhanced software development workflow",
   "author": {
     "name": "Ladislav Martincik",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the SDLC Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2025-12-29
+
+### Added
+- **`/review` command** - Parallel code review with GPT-5.2-Codex and Gemini 3 Pro
+  - Reviews git diff (staged + unstaged changes by default)
+  - Runs both reviewers concurrently for speed
+  - Consolidates findings with deduplication
+  - Priority-based organization (P0-P3)
+  - Consensus flagging when both reviewers agree
+  - Unified markdown report with overall verdict
+
+- **GPT-5.2-Codex support** - New flagship model for code review
+  - `gpt-5.2-codex` added to Codex skill model options
+  - 79% SWE-bench Pro performance
+  - Optimized for xhigh reasoning effort
+
+- **`xhigh` reasoning effort** - Maximum quality setting for Codex
+  - Best for code review, security analysis, architecture review
+  - Requires `gpt-5.2-codex` model
+
+### Enhanced
+- **Codex skill** - Added Code Review Mode section with review command pattern and output format
+- **README** - Documented new `/review` command with usage examples
+
 ## [1.4.0] - 2025-12-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ A comprehensive Claude Code plugin that enhances your software development lifec
 - **/plan** - Generate detailed implementation plans with phases, complexity analysis, and validation steps
 - **/research** - AI-powered research with project context
 - **/implement** - Execute implementation based on generated plans
+- **/review** - Parallel code review with GPT-5.2-Codex and Gemini 3 Pro, consolidated findings
 - **/submit** - Prepare and submit work for review
 - **/verify** - Validate implementation against acceptance criteria
 
 ### 🎯 Skills
 
-- **codex** - OpenAI GPT-5.1-Codex integration for advanced code analysis, refactoring, and automated editing
+- **codex** - OpenAI Codex integration (GPT-5.1/5.2) for code analysis, review, refactoring, and automated editing
 - **gemini** - Google Gemini 3 Pro integration for code review, plan analysis, and big context (>200k) processing
 
 ### 🔌 Integrations
@@ -179,6 +180,19 @@ OR
 ```
 
 Executes the implementation plan with guided steps. Updates GitHub Issue checkboxes during work.
+
+#### Code Review
+
+```bash
+/review                      # Review current changes (staged + unstaged)
+/review origin/main...HEAD   # Review all commits on branch
+```
+
+Runs parallel code reviews with GPT-5.2-Codex (xhigh reasoning) and Gemini 3 Pro:
+- Analyzes git diff for correctness, performance, security, maintainability
+- Deduplicates findings when both reviewers flag the same issue
+- Prioritizes by severity (P0-P3)
+- Consolidates into unified markdown report with overall verdict
 
 #### Verification
 
@@ -398,6 +412,7 @@ sdlc-plugin/
 │   ├── plan.md
 │   ├── research.md
 │   ├── implement.md
+│   ├── review.md
 │   ├── submit.md
 │   └── verify.md
 ├── skills/

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,0 +1,210 @@
+# Parallel Code Review with Codex and Gemini
+
+Run comprehensive code reviews using GPT-5.2-Codex and Gemini 3 Pro in parallel, then consolidate findings into a unified report.
+
+## Session Naming
+
+Before starting, rename this session for clarity:
+- If `$ARGUMENTS` provided: `/rename "Review: $ARGUMENTS"`
+- Otherwise: `/rename "Review: Current Changes"`
+
+## Instructions
+
+### 1. Get the Diff to Review
+
+Capture the changes to review:
+
+```bash
+# Default: all staged + unstaged changes
+git diff HEAD
+
+# If $ARGUMENTS specifies a commit range (e.g., "origin/main...HEAD"), use that instead
+```
+
+If `$ARGUMENTS` contains a commit range or file paths, use those. Otherwise default to `git diff HEAD`.
+
+Store the diff output for both reviewers.
+
+### 2. Spawn Parallel Review Agents
+
+Create two Task agents to run reviews concurrently. **IMPORTANT**: Spawn both agents in a single message to run them in parallel.
+
+#### Codex Review Agent
+
+Use the `codex` skill with these settings:
+- Model: `gpt-5.2-codex`
+- Sandbox: `read-only`
+- Reasoning effort: `xhigh`
+- Full auto mode
+
+**Codex command:**
+```bash
+codex exec --skip-git-repo-check \
+  -m gpt-5.2-codex \
+  -c model_reasoning_effort="xhigh" \
+  --sandbox read-only \
+  --full-auto \
+  "You are a code reviewer. Review the following git diff for issues.
+
+Focus on:
+- Correctness and logic errors
+- Performance implications
+- Security vulnerabilities
+- Maintainability concerns
+
+Flag only actionable issues INTRODUCED by this change. Skip trivial nits.
+
+For each finding, provide:
+### [TITLE] (P{0-3}, confidence: {0.0-1.0})
+**File**: \`path/to/file\` lines {start}-{end}
+{explanation}
+
+Priority levels:
+- P0: Critical (security, data loss, crashes)
+- P1: High (logic errors, significant bugs)
+- P2: Medium (code quality, maintainability)
+- P3: Low (style, minor suggestions)
+
+End with:
+## Overall Verdict
+**Assessment**: [patch is correct / patch is incorrect]
+**Confidence**: {0.0-1.0}
+**Justification**: {brief explanation}
+
+---
+GIT DIFF:
+$(git diff HEAD)" 2>/dev/null
+```
+
+#### Gemini Review Agent
+
+Use the `gemini` skill with these settings:
+- Model: `gemini-3-pro-preview`
+- Approval mode: `yolo` (required for background execution)
+- Timeout: 300s safety wrapper
+
+**Gemini command:**
+```bash
+timeout 300 gemini -m gemini-3-pro-preview --approval-mode yolo \
+  "You are a code reviewer. Review the following git diff for issues.
+
+Focus on:
+- Correctness and logic errors
+- Performance implications
+- Security vulnerabilities
+- Maintainability concerns
+
+Flag only actionable issues INTRODUCED by this change. Skip trivial nits.
+
+For each finding, provide:
+### [TITLE] (P{0-3}, confidence: {0.0-1.0})
+**File**: \`path/to/file\` lines {start}-{end}
+{explanation}
+
+Priority levels:
+- P0: Critical (security, data loss, crashes)
+- P1: High (logic errors, significant bugs)
+- P2: Medium (code quality, maintainability)
+- P3: Low (style, minor suggestions)
+
+End with:
+## Overall Verdict
+**Assessment**: [APPROVE / REQUEST_CHANGES]
+**Confidence**: {0.0-1.0}
+**Justification**: {brief explanation}
+
+---
+GIT DIFF:
+$(git diff HEAD)"
+```
+
+### 3. Wait for Both Reviews
+
+**CRITICAL**: Wait for ALL review agents to complete before proceeding. Do not start consolidation until both have returned.
+
+### 4. Consolidate Findings
+
+Merge the two review outputs:
+
+1. **Parse findings** from each reviewer (look for `### [TITLE]` pattern)
+2. **Deduplicate** overlapping issues:
+   - Same file + overlapping line ranges + similar issue = merge into one
+   - Note which reviewers flagged it
+3. **Flag consensus**: When both reviewers identify the same issue, mark as "consensus" (higher confidence)
+4. **Sort by priority**: P0 first, then P1, P2, P3
+5. **Within priority**: Sort by confidence score (highest first)
+
+### 5. Generate Consolidated Report
+
+Output the final report in this format:
+
+```markdown
+# Code Review Report
+
+**Scope**: `git diff HEAD` (or specified range)
+**Date**: [current timestamp]
+**Reviewers**: GPT-5.2-Codex (xhigh), Gemini 3 Pro
+
+## Summary
+
+| Priority | Count | Description |
+|----------|-------|-------------|
+| P0 | X | Critical issues requiring immediate attention |
+| P1 | X | High priority issues |
+| P2 | X | Medium priority issues |
+| P3 | X | Low priority / suggestions |
+
+**Overall Verdict**:
+- Codex: [patch is correct/incorrect] (confidence: X.XX)
+- Gemini: [APPROVE/REQUEST_CHANGES] (confidence: X.XX)
+- **Consensus**: [APPROVE / REQUEST_CHANGES / MIXED]
+
+## Critical Issues (P0)
+
+### [Title]
+**File**: `path/to/file.ts` lines 45-52
+**Flagged by**: Codex, Gemini (consensus)
+**Confidence**: 0.95
+
+[Detailed explanation merging insights from both reviewers]
+
+---
+
+## High Priority (P1)
+
+[findings...]
+
+## Medium Priority (P2)
+
+[findings...]
+
+## Low Priority (P3)
+
+[findings...]
+
+## Reviewer Disagreements
+
+[Any findings where reviewers had significantly different assessments - one flagged, one didn't, or different priorities]
+
+---
+*Generated by /sdlc:review using GPT-5.2-Codex and Gemini 3 Pro*
+```
+
+### 6. Present Results
+
+After generating the report:
+- Display the full consolidated report
+- Highlight any P0/P1 issues that need immediate attention
+- If no issues found: "No significant issues found. Code looks good to proceed."
+
+## Scope
+
+$ARGUMENTS
+
+## Notes
+
+- If the diff is empty, inform the user: "No changes to review. Stage some changes or specify a commit range."
+- For very large diffs (>10k lines), consider reviewing in chunks or warning the user about token limits
+- Both reviewers run in read-only mode - they cannot modify files
+- Codex uses xhigh reasoning for maximum review quality
+- Gemini uses yolo mode for background execution (will not hang)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-plugin",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations",
   "private": true,
   "type": "module",

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -34,6 +34,7 @@ description: Use when the user asks to run Codex CLI (codex exec, codex resume) 
 
 | Model | Best for | Context window | Key features |
 | --- | --- | --- | --- |
+| `gpt-5.2-codex` ⭐⭐ | **Code review flagship**: xhigh reasoning, security analysis, architecture review | 400K input / 128K output | 79% SWE-bench Pro, best for reviews |
 | `gpt-5.1-codex` ⭐ | **Flagship model**: Software engineering, agentic coding workflows | 400K input / 128K output | 76.3% SWE-bench, adaptive reasoning, $1.25/$10.00 |
 | `gpt-5.1-codex-mini` | Cost-efficient coding (4x more usage allowance) | 400K input / 128K output | Near SOTA performance, $0.25/$2.00 |
 | `gpt-5.1-thinking` | Ultra-complex reasoning, deep problem analysis | 400K input / 128K output | Adaptive thinking depth, runs 2x slower on hardest tasks |
@@ -41,6 +42,7 @@ description: Use when the user asks to run Codex CLI (codex exec, codex resume) 
 **GPT-5.1-Codex Advantages**: 76.3% SWE-bench (vs 72.8% GPT-5), 30% faster on average tasks, better tool handling, reduced hallucinations, improved code quality. Knowledge cutoff: September 30, 2024.
 
 **Reasoning Effort Levels**:
+- `xhigh` - Maximum quality (code review, security analysis, architecture review) - requires `gpt-5.2-codex`
 - `high` - Complex tasks (refactoring, architecture, security analysis, performance optimization)
 - `medium` - Standard tasks (refactoring, code organization, feature additions, bug fixes)
 - `low` - Simple tasks (quick fixes, simple changes, code formatting, documentation)
@@ -56,6 +58,35 @@ description: Use when the user asks to run Codex CLI (codex exec, codex resume) 
 - Stop and report failures whenever `codex --version` or a `codex exec` command exits non-zero; request direction before retrying.
 - Before you use high-impact flags (`--full-auto`, `--sandbox danger-full-access`, `--skip-git-repo-check`) ask the user for permission using AskUserQuestion unless it was already given.
 - When output includes warnings or partial results, summarize them and ask how to adjust using `AskUserQuestion`.
+
+## Code Review Mode
+
+For automated code reviews with maximum quality, use `gpt-5.2-codex` with `xhigh` reasoning:
+
+### Review Command Pattern
+```bash
+codex exec --skip-git-repo-check \
+  -m gpt-5.2-codex \
+  -c model_reasoning_effort="xhigh" \
+  --sandbox read-only \
+  --full-auto \
+  "[review prompt with diff]" 2>/dev/null
+```
+
+### Review Output Format
+Structure findings with priority levels:
+- **P0** - Critical: Security vulnerabilities, data loss, crashes
+- **P1** - High: Logic errors, significant bugs, performance issues
+- **P2** - Medium: Code quality, maintainability concerns
+- **P3** - Low: Style, minor improvements, suggestions
+
+Each finding should include:
+- Title (max 80 chars)
+- File path and line range
+- Confidence score (0-1)
+- Detailed explanation
+
+End with overall verdict: "patch is correct" or "patch is incorrect" with justification.
 
 ## CLI Version
 


### PR DESCRIPTION
## Summary

Adds a new `/review` command that runs parallel code reviews using GPT-5.2-Codex and Gemini 3 Pro, then consolidates findings into a unified markdown report.

**Key features:**
- Reviews git diff (staged + unstaged changes by default)
- Runs both reviewers concurrently for speed
- GPT-5.2-Codex with `xhigh` reasoning for maximum quality
- Gemini 3 Pro with `yolo` mode for background execution
- Consolidates findings with deduplication
- Priority-based organization (P0-P3)
- Consensus flagging when both reviewers agree
- Unified markdown report with overall verdict

## Changes

- `commands/review.md` - New parallel review command
- `skills/codex/SKILL.md` - Added gpt-5.2-codex model, xhigh reasoning, Code Review Mode section
- `README.md` - Documented /review command with usage examples
- `CHANGELOG.md` - v1.5.0 entry
- Version bumped to 1.5.0

## Usage

```bash
/review                      # Review current changes
/review origin/main...HEAD   # Review all commits on branch
```

## Test plan

- [ ] Verify `/review` command is recognized
- [ ] Test with git changes present
- [ ] Confirm parallel execution of Codex and Gemini
- [ ] Validate consolidated output format