### PR TITLE
feat: add /interview skill and smart ambiguity detection for /plan

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations for enhanced software development workflow",
   "author": {
     "name": "Ladislav Martincik",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the SDLC Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2025-12-29
+
+### Added
+- **`/interview` skill** - Deep interviews about any topic using Opus model
+  - Works on files (plans, code) or topics/ideas
+  - Iterative questioning with AskUserQuestion
+  - Non-obvious questions that dig deep
+  - Updates files in-place or summarizes insights
+
+- **Smart interview phase for `/plan`** - Asks questions only when genuinely ambiguous
+  - Detects ambiguities before generating plan content
+  - Asks focused questions about architecture, scope, tradeoffs
+  - Skips obvious questions that can be inferred
+  - References `/interview` for deeper follow-up
+
+### Enhanced
+- **`/plan` command** - Now includes "Phase 0: Ambiguity Detection" before planning
+- **README** - Added interview skill documentation and usage examples
+
 ## [1.5.0] - 2025-12-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A comprehensive Claude Code plugin that enhances your software development lifec
 
 - **codex** - OpenAI Codex integration (GPT-5.1/5.2) for code analysis, review, refactoring, and automated editing
 - **gemini** - Google Gemini 3 Pro integration for code review, plan analysis, and big context (>200k) processing
+- **interview** - Deep interviews about any topic with iterative questioning (uses Opus)
 
 ### 🔌 Integrations
 
@@ -353,6 +354,11 @@ Skills are invoked when you reference their capabilities:
 
 # Gemini
 "Use gemini to analyze this architecture"
+
+# Interview
+/interview plans/my-feature.md           # Interview about a plan file
+/interview "authentication system"       # Interview about a concept
+/interview src/auth/login.ts             # Interview about existing code
 ```
 
 ## Configuration
@@ -417,7 +423,8 @@ sdlc-plugin/
 │   └── verify.md
 ├── skills/
 │   ├── codex/SKILL.md
-│   └── gemini/SKILL.md
+│   ├── gemini/SKILL.md
+│   └── interview/SKILL.md
 ├── utils/
 │   └── perplexity-mcp/
 │       └── index.js         # Perplexity MCP server

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -10,6 +10,38 @@ Before starting, rename this session for clarity:
 
 ## Instructions
 
+### Phase 0: Ambiguity Detection (BEFORE planning)
+
+Before generating any plan content, analyze the task for genuine ambiguities:
+
+1. **Identify ambiguous areas** that meaningfully affect the plan:
+   - Multiple valid architecture approaches
+   - Unclear scope boundaries (what's in/out)
+   - Technology choices with real tradeoffs
+   - User intent that could be interpreted differently
+   - Priority decisions (performance vs simplicity, etc.)
+
+2. **If ambiguities exist**: Use `AskUserQuestion` to clarify BEFORE filling the template
+   - Ask 1-4 focused questions using multi-choice options
+   - Only ask questions that meaningfully affect the implementation
+   - Skip obvious questions - don't ask what you can reasonably infer
+
+3. **If the request is clear and specific**: Skip to planning phase
+
+**Example ambiguities worth asking about:**
+- "Should this run synchronously or in background?"
+- "Is offline support needed in first version?"
+- "Should errors be user-facing or logged silently?"
+
+**DON'T ask:**
+- "Do you want tests?" (always yes)
+- "What should we name it?" (can infer from context)
+- "Should we use TypeScript?" (check existing codebase)
+
+For complex plans requiring deeper exploration, recommend the user run `/interview` on the plan after creation.
+
+### Phase 1: Planning
+
 - IMPORTANT: You're writing a plan to resolve a task based on the `Plan` that will add value to the application.
 - IMPORTANT: The `Plan` describes the problem that will be resolved but remember we're not resolving the task, we're creating the plan that will be used to resolve the task based on the `Plan Format` below.
 - You're writing a plan to resolve a task, it should be thorough and precise so we fix the root cause and prevent regressions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-plugin",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations",
   "private": true,
   "type": "module",

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: interview
+description: Interview me about anything in depth
+argument-hint: [topic or file]
+model: opus
+---
+
+# Deep Interview Skill
+
+Conduct an in-depth interview about any topic, file, or idea the user provides.
+
+## Detecting Input Type
+
+First, determine what the user wants to discuss:
+
+1. **If `$1` looks like a file path** (contains `/`, `.md`, `.ts`, etc.):
+   - Read the file using the Read tool
+   - Interview about its contents
+   - At the end, update the file in-place with refined insights
+
+2. **If `$1` is a topic or description**:
+   - Interview about that concept/idea
+   - At the end, summarize the key insights
+
+## Interview Process
+
+### Round-by-Round Approach
+
+Interview iteratively - one round of questions at a time:
+
+1. **Analyze** what you know so far
+2. **Identify** the most important ambiguities, assumptions, or unexplored areas
+3. **Ask 1-4 questions** using `AskUserQuestion` tool
+4. **Process** the answers
+5. **Repeat** until the user says "done" or you've covered everything meaningful
+
+### Question Quality Rules
+
+**DO ask about:**
+- Implementation tradeoffs ("Should this be sync or async?")
+- Edge cases ("What happens when the input is empty?")
+- Scope boundaries ("Is X in scope for the first version?")
+- User preferences ("Do you prefer explicit errors or silent fallbacks?")
+- Architecture choices ("Should this be a separate service or integrated?")
+- Constraints ("Are there performance requirements?")
+- Alternatives ("Have you considered approach Y instead?")
+
+**DON'T ask:**
+- Obvious things ("Do you want tests?")
+- Things you can infer ("What language should we use?" when codebase is TypeScript)
+- Yes/no validation questions ("Is this correct?")
+- Surface-level stuff ("What's the feature name?")
+
+### Question Format
+
+Always use `AskUserQuestion` with multiple choice options when possible:
+
+```
+AskUserQuestion:
+  questions:
+    - question: "How should the system handle API failures?"
+      header: "Error handling"
+      options:
+        - label: "Retry with backoff"
+          description: "Automatically retry failed requests with exponential backoff"
+        - label: "Fail fast"
+          description: "Return error immediately, let caller decide"
+        - label: "Queue for later"
+          description: "Store failed requests and retry in background"
+      multiSelect: false
+```
+
+### Interview Categories
+
+Adapt questions based on context, but consider exploring:
+
+1. **Technical Implementation**
+   - Architecture patterns
+   - Technology choices
+   - Integration points
+   - Data flow
+
+2. **User Experience**
+   - Interaction patterns
+   - Error states
+   - Edge cases
+   - Feedback mechanisms
+
+3. **Constraints & Requirements**
+   - Performance needs
+   - Security considerations
+   - Scalability requirements
+   - Compliance/regulatory
+
+4. **Scope & Priorities**
+   - Must-have vs nice-to-have
+   - First version vs future iterations
+   - Dependencies and blockers
+
+5. **Risks & Concerns**
+   - What could go wrong?
+   - What are you uncertain about?
+   - What alternatives exist?
+
+## Completion
+
+When the interview is complete (user says "done" or all areas explored):
+
+**For file input:**
+1. Summarize key decisions made during the interview
+2. Update the original file with refined information
+3. Add an "Interview Insights" or similar section if appropriate
+4. Preserve the original structure
+
+**For topic input:**
+1. Provide a comprehensive summary of insights gathered
+2. List key decisions and preferences discovered
+3. Highlight any unresolved questions or areas for future exploration
+
+## Topic
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary

Adds a new `/interview` skill for deep iterative questioning and improves `/plan` with smart ambiguity detection.

**New `/interview` skill:**
- General-purpose deep interview using Opus model
- Works on any file (plans, code) or topic/idea
- Iterative questioning with AskUserQuestion
- Non-obvious questions that dig deep into:
  - Technical implementation choices
  - Edge cases and error handling
  - Scope and priority tradeoffs
  - Architecture decisions
- Updates files in-place or summarizes insights

**`/plan` improvements:**
- Added "Phase 0: Ambiguity Detection" before generating plan content
- Only asks questions when genuinely ambiguous (architecture, scope, tradeoffs)
- Skips obvious questions that can be reasonably inferred
- References `/interview` for deeper follow-up on complex plans

## Usage

```bash
/interview plans/my-feature.md           # Interview about a plan file
/interview "authentication system"       # Interview about a concept
/interview src/auth/login.ts             # Interview about existing code
```

## Changes

- `skills/interview/SKILL.md` - New interview skill
- `commands/plan.md` - Added ambiguity detection phase
- `README.md` - Added interview skill documentation
- `CHANGELOG.md` - v1.6.0 entry
- Version bumped to 1.6.0

## Test plan

- [ ] Verify `/interview` skill is recognized
- [ ] Test with plan file input
- [ ] Test with topic/idea input
- [ ] Verify `/plan` asks questions for ambiguous requests
- [ ] Verify `/plan` skips questions for clear requests