### PR TITLE
feat: default interview integration for plan, research, and implement

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations for enhanced software development workflow",
   "author": {
     "name": "Ladislav Martincik",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the SDLC Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2026-02-09
+
+### Added
+
+- **Default interview integration** for `/plan`, `/research`, and `/implement` commands
+  - Interview runs automatically before main workflow — no manual `/interview` invocation required
+  - `/plan`: Replaced conditional Ambiguity Detection Checkpoint with unconditional Interview Checkpoint
+  - `/research`: Added Interview Checkpoint before Context Gathering (Standard) and Context Preparation (Swarm)
+  - `/implement`: Added Interview Checkpoint after Plan Input, before Mode Selection — uses parsed plan content as topic, not raw file path
+  - All three commands reference `skills/interview/SKILL.md` via Glob with conversation-context-only override
+  - New `has-interview-checkpoint` structural eval assertions for plan, research, and implement
+
 ## [1.16.0] - 2026-02-09
 
 ### Added

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -30,6 +30,17 @@ Parse the plan reference:
 
 Read plan completely, check Issue for progress, read all referenced files (no limit/offset). Extract tasks from phases.
 
+### Interview Checkpoint
+
+Find and read the interview protocol using Glob:
+- Pattern: `**/sdlc/**/skills/interview/SKILL.md`
+- Search path: `~/.claude/plugins`
+
+Execute the interview protocol with these overrides:
+- Output to conversation context only — do not update files or write an Interview Insights section
+- Focus on: task ordering preferences, testing approach, code style choices, areas where the plan leaves decisions open
+- The topic for the interview is the plan's goals and requirements as parsed in the Plan Input step above
+
 ### Mode Selection
 
 **If user requested swarm mode** (via `--swarm` flag): Execute the **Swarm Workflow** below.

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -19,8 +19,8 @@ Create a comprehensive PRD in `plans/*.md` that resolves the given task. The pla
 **Research codebase first (start with README.md, then relevant files)**
 Plans based on assumptions rather than actual code state lead to mismatched implementations.
 
-**Detect genuine ambiguities before planning**
-Early ambiguity detection is cheaper than replanning after implementation starts.
+**Interview the user before planning**
+Upfront interviews are cheaper than replanning after implementation starts.
 
 **Fill every section of the PRD template completely**
 Incomplete plans cause implementation ambiguity and require mid-task clarifications that break flow.
@@ -90,8 +90,15 @@ Load these files before proceeding (use Glob with path `~/.claude/plugins`):
 
 ## Workflow
 
-**Ambiguity Detection Checkpoint**
-Analyze for genuine ambiguities (architecture, scope, technology, intent). If found, use `AskUserQuestion` with 1-4 focused questions.
+**Interview Checkpoint**
+Find and read the interview protocol using Glob:
+- Pattern: `**/sdlc/**/skills/interview/SKILL.md`
+- Search path: `~/.claude/plugins`
+
+Execute the interview protocol with these overrides:
+- Output to conversation context only — do not update files or write an Interview Insights section
+- Focus on: architecture approaches, scope boundaries, technology choices, user intent, priority tradeoffs
+- The topic for the interview is: the user's task as provided in $ARGUMENTS
 
 **Research Checkpoint**
 Read README.md to understand architecture patterns and conventions, then explore relevant codebase files to map existing abstractions and integration points. Plans grounded in actual code state avoid mismatched implementations.

--- a/commands/research.md
+++ b/commands/research.md
@@ -36,9 +36,22 @@ If no topic remains after flag extraction, ask the user for a research question 
 
 The default research approach uses specialized subagents to explore different aspects of the codebase in parallel.
 
+### Interview Checkpoint
+
+Find and read the interview protocol using Glob:
+- Pattern: `**/sdlc/**/skills/interview/SKILL.md`
+- Search path: `~/.claude/plugins`
+
+Execute the interview protocol with these overrides:
+- Output to conversation context only — do not update files or write an Interview Insights section
+- Focus on: research scope, focus areas, depth vs breadth, intended use of research output
+- The topic for the interview is: the research topic as parsed from $ARGUMENTS
+
 ### Context Gathering
 
 Read any files the user mentioned completely before delegating work. This provides grounding for the subagents and ensures you understand what the user is starting from.
+
+Include interview decisions and focus areas when summarizing context for subagent prompts.
 
 ### Parallel Investigation
 
@@ -73,9 +86,22 @@ Attempt to create the agent team using `TeamCreate` with a unique timestamped na
 
 If team creation fails (tool unavailable or experimental features disabled), inform the user that swarm mode requires agent teams to be enabled (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in settings.json), then fall back to executing the Standard Workflow instead. The research topic is already parsed and ready to use.
 
+### Interview Checkpoint
+
+Find and read the interview protocol using Glob:
+- Pattern: `**/sdlc/**/skills/interview/SKILL.md`
+- Search path: `~/.claude/plugins`
+
+Execute the interview protocol with these overrides:
+- Output to conversation context only — do not update files or write an Interview Insights section
+- Focus on: research scope, focus areas, depth vs breadth, intended use of research output
+- The topic for the interview is: the research topic as parsed from $ARGUMENTS
+
 ### Context Preparation
 
 Before spawning teammates, read any user-mentioned files completely and understand the research question. Summarize this context in the teammate spawn prompts so they start with shared understanding.
+
+Include interview decisions and focus areas when summarizing context in the teammate spawn prompts.
 
 ### Shared Task List
 

--- a/eval/cases/implement.eval.ts
+++ b/eval/cases/implement.eval.ts
@@ -20,6 +20,10 @@ const evalCase: EvalCase = {
       test: (content) => /^## Plan/m.test(content) && /\$ARGUMENTS/.test(content)
     },
     {
+      name: 'has-interview-checkpoint',
+      test: (content) => /interview.*protocol|interview.*SKILL/i.test(content)
+    },
+    {
       name: 'has-progress-tracking',
       test: (content) => /progress.*track|todo.*list/i.test(content)
     },

--- a/eval/cases/plan.eval.ts
+++ b/eval/cases/plan.eval.ts
@@ -24,6 +24,10 @@ const evalCase: EvalCase = {
       test: (content) => /\$ARGUMENTS/.test(content)
     },
     {
+      name: 'has-interview-checkpoint',
+      test: (content) => /interview.*protocol|interview.*SKILL/i.test(content)
+    },
+    {
       name: 'has-prd-template-content',
       test: (content) => /## Metadata/.test(content) &&
                           /## Overview/.test(content) &&

--- a/eval/cases/research.eval.ts
+++ b/eval/cases/research.eval.ts
@@ -19,6 +19,10 @@ const evalCase: EvalCase = {
       test: (content) => /parallel.*agent|Task.*agent|sub-agent/i.test(content)
     },
     {
+      name: 'has-interview-checkpoint',
+      test: (content) => /interview.*protocol|interview.*SKILL/i.test(content)
+    },
+    {
       name: 'has-frontmatter-template',
       test: (content) => /---\s*\n.*\ndate:.*\ngit_commit:/s.test(content) ||
                           /frontmatter/i.test(content)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-plugin",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

- **`/plan`**: Replaced conditional Ambiguity Detection Checkpoint with unconditional Interview Checkpoint referencing `skills/interview/SKILL.md` via Glob
- **`/research`**: Added Interview Checkpoint before Context Gathering (Standard) and Context Preparation (Swarm), with interview context propagation to subagent prompts
- **`/implement`**: Added Interview Checkpoint after Plan Input, before Mode Selection — uses parsed plan content as topic, not raw `$ARGUMENTS` file path
- Added `has-interview-checkpoint` structural eval assertions for all three commands
- Version bump: 1.16.0 → 1.17.0

## Context

Plan: `plans/default-interview-integration.md`

The interview skill was introduced in v1.6.0 but required manual `/interview` invocation. This makes it the default first step in all three commands, fulfilling the original vision.

## Test plan

- [x] `bun run validate` — versions synchronized at 1.17.0
- [x] `bun run eval` — 160/160 structural assertions passing (3 new)
- [x] No "Ambiguity Detection" text remains in plan.md
- [x] Interview Checkpoint present in plan.md, research.md (2x), implement.md
- [x] Interview context propagation in research.md Context Gathering and Context Preparation
- [x] Implement interview topic uses parsed plan goals, not raw `$ARGUMENTS`