### PR TITLE
fix: --swarm flag silently ignored in /research and /research-deep

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations for enhanced software development workflow",
   "author": {
     "name": "Ladislav Martincik",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the SDLC Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.1] - 2026-02-10
+
+### Fixed
+
+- **`/research --swarm` routing** — replaced advisory "Argument Parsing" + "Mode Selection" with imperative "CRITICAL: Route Selection" gate; reordered Swarm Workflow before Standard Workflow to prevent top-to-bottom execution bias
+- **`/research-deep --swarm` routing** — strengthened "CRITICAL: Parse Flags and Route" with imperative skip directives; reordered Swarm Discovery before Standard Discovery
+
 ## [1.18.0] - 2026-02-10
 
 ### Changed

--- a/commands/research-deep.md
+++ b/commands/research-deep.md
@@ -14,9 +14,9 @@ Depth (multi-perspective) > Accuracy (consensus validation) > Concision
 
 Execute 3-phase multi-LLM research (Discovery → Analysis → Synthesis) on a codebase topic, producing a comprehensive document with LLM attribution markers showing which findings came from Claude, Gemini, and/or Codex.
 
-## Argument Parsing
+## CRITICAL: Parse Flags and Route
 
-Parse `$ARGUMENTS` for flags before processing:
+BEFORE doing anything else, parse `$ARGUMENTS` for flags:
 1. Check if `--swarm` appears as a standalone token (not inside quotes)
 2. If found: set `SWARM_MODE=true`, remove all `--swarm` tokens from the argument string
 3. The remaining text (trimmed) is the research topic
@@ -26,15 +26,8 @@ Parse `$ARGUMENTS` for flags before processing:
 
 ### Phase 1: Discovery
 
-**If `SWARM_MODE=true`**: Use the **Swarm Discovery** workflow below.
-**Otherwise**: Use the **Standard Discovery** workflow below.
-
-#### Standard Discovery (Claude only)
-- Read any user-mentioned files first
-- Create `research/.deep-research-$(date +%Y%m%d-%H%M%S)/`
-- Spawn one discovery agent using codebase-locator, codebase-analyzer, and codebase-pattern-finder
-- Target <50K characters for CLI compatibility
-- Save to `context.md`
+If `SWARM_MODE=true`: skip directly to **Swarm Discovery** below. Do NOT execute Standard Discovery.
+If `SWARM_MODE` is not set: skip directly to **Standard Discovery** below. Do NOT execute Swarm Discovery.
 
 #### Swarm Discovery (Agent Team)
 
@@ -155,6 +148,14 @@ Collect all teammate findings and write them to `context.md` in the working dire
 3. Call `TeamDelete` to remove the team and its task list
 
 If cleanup itself fails, inform the user but continue to Phase 2: "Team cleanup incomplete. You may need to check for lingering team resources."
+
+#### Standard Discovery (Claude only)
+
+- Read any user-mentioned files first
+- Create `research/.deep-research-$(date +%Y%m%d-%H%M%S)/`
+- Spawn one discovery agent using codebase-locator, codebase-analyzer, and codebase-pattern-finder
+- Target <50K characters for CLI compatibility
+- Save to `context.md`
 
 ---
 

--- a/commands/research.md
+++ b/commands/research.md
@@ -16,63 +16,14 @@ Research and document the codebase to answer the given question. Produce a stand
 
 Read documentarian constraints (Glob `**/sdlc/**/references/documentarian-constraints.md`, path `/Users/iamladi/Projects/claude-code-plugins`). YOUR ONLY JOB IS TO DOCUMENT AND EXPLAIN THE CODEBASE AS IT EXISTS TODAY. DO NOT suggest improvements or changes unless explicitly requested. Document what IS, not what SHOULD BE.
 
-### Argument Parsing
+### CRITICAL: Route Selection
 
-The `$ARGUMENTS` input contains both the research topic and optional mode flags. Extract the intent:
-- Identify if `--swarm` flag is present (indicates user wants parallel team research)
-- Separate the flag from the research topic itself
-- The research topic is the remaining text after flag extraction
+BEFORE taking any other action, check `$ARGUMENTS` for the `--swarm` flag:
 
-If no topic remains after flag extraction, ask the user for a research question before proceeding.
+1. If `--swarm` IS present: remove it from the arguments (the remaining text is the research topic), then skip directly to **Swarm Workflow**. Do NOT execute any Standard Workflow steps.
+2. If `--swarm` is NOT present: the full `$ARGUMENTS` is the research topic, skip directly to **Standard Workflow**. Do NOT execute any Swarm Workflow steps.
 
-### Mode Selection
-
-**If user requested swarm mode** (via `--swarm` flag): Execute the **Swarm Workflow** below.
-**Otherwise**: Execute the **Standard Workflow** below.
-
----
-
-## Standard Workflow
-
-The default research approach uses specialized subagents to explore different aspects of the codebase in parallel.
-
-### Interview Checkpoint
-
-Find and read the interview protocol using Glob:
-- Pattern: `**/sdlc/**/skills/interview/SKILL.md`
-- Search path: `~/.claude/plugins`
-
-Execute the interview protocol with these overrides:
-- Output to conversation context only — do not update files or write an Interview Insights section
-- Focus on: research scope, focus areas, depth vs breadth, intended use of research output
-- The topic for the interview is: the research topic as parsed from $ARGUMENTS
-
-### Context Gathering
-
-Read any files the user mentioned completely before delegating work. This provides grounding for the subagents and ensures you understand what the user is starting from.
-
-Include interview decisions and focus areas when summarizing context for subagent prompts.
-
-### Parallel Investigation
-
-Spawn subagents with complementary perspectives on the research question:
-- **Locator**: Discovers where relevant code lives (files, directories, components)
-- **Analyzer**: Understands how the code works (data flow, interactions, implementation)
-- **Pattern Finder**: Identifies conventions and similar implementations elsewhere
-
-These roles work best when they have judgment latitude about HOW to investigate, while being clear on WHAT they're investigating. Each subagent should determine its own search strategy based on what it discovers.
-
-### Optional Web Research
-
-If the user explicitly requested information that requires web search (external APIs, library documentation, recent changes), spawn a web-search-researcher subagent alongside the codebase investigators.
-
-### Source Requirements
-
-All findings must trace back to specific locations in the codebase (file:line references). Prioritize the live codebase over existing documentation when they conflict — code is the source of truth.
-
-### Synthesis
-
-Wait for all subagents to complete their investigation. Integrate their findings into a coherent research document that answers the original question, preserving all source attributions.
+If no research topic remains after processing, ask the user for a research question before proceeding.
 
 ---
 
@@ -173,6 +124,50 @@ Send shutdown requests to all teammates via `SendMessage` with `type: "shutdown_
 If cleanup itself fails, inform the user: "Team cleanup incomplete. You may need to check for lingering team resources."
 
 Execute cleanup regardless of synthesis outcome — even if earlier steps errored or teammates timed out, cleanup must run before ending.
+
+---
+
+## Standard Workflow
+
+The default research approach uses specialized subagents to explore different aspects of the codebase in parallel.
+
+### Interview Checkpoint
+
+Find and read the interview protocol using Glob:
+- Pattern: `**/sdlc/**/skills/interview/SKILL.md`
+- Search path: `~/.claude/plugins`
+
+Execute the interview protocol with these overrides:
+- Output to conversation context only — do not update files or write an Interview Insights section
+- Focus on: research scope, focus areas, depth vs breadth, intended use of research output
+- The topic for the interview is: the research topic as parsed from $ARGUMENTS
+
+### Context Gathering
+
+Read any files the user mentioned completely before delegating work. This provides grounding for the subagents and ensures you understand what the user is starting from.
+
+Include interview decisions and focus areas when summarizing context for subagent prompts.
+
+### Parallel Investigation
+
+Spawn subagents with complementary perspectives on the research question:
+- **Locator**: Discovers where relevant code lives (files, directories, components)
+- **Analyzer**: Understands how the code works (data flow, interactions, implementation)
+- **Pattern Finder**: Identifies conventions and similar implementations elsewhere
+
+These roles work best when they have judgment latitude about HOW to investigate, while being clear on WHAT they're investigating. Each subagent should determine its own search strategy based on what it discovers.
+
+### Optional Web Research
+
+If the user explicitly requested information that requires web search (external APIs, library documentation, recent changes), spawn a web-search-researcher subagent alongside the codebase investigators.
+
+### Source Requirements
+
+All findings must trace back to specific locations in the codebase (file:line references). Prioritize the live codebase over existing documentation when they conflict — code is the source of truth.
+
+### Synthesis
+
+Wait for all subagents to complete their investigation. Integrate their findings into a coherent research document that answers the original question, preserving all source attributions.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-plugin",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

- **`/research`**: Replaced advisory "Argument Parsing" + "Mode Selection" with imperative "CRITICAL: Route Selection" gate; reordered Swarm Workflow before Standard Workflow
- **`/research-deep`**: Strengthened "CRITICAL: Parse Flags and Route" with imperative skip directives; reordered Swarm Discovery before Standard Discovery

## Root Cause

The LLM read the command prompt top-to-bottom and started executing the first actionable section (Standard Workflow) before processing the routing gate. The weak advisory language ("If user requested swarm mode, execute Swarm Workflow below") wasn't treated as a hard stop.

## Test plan

- [ ] `/research --swarm topic` triggers agent team creation and spawns 3 teammates (Locator, Analyzer, Pattern Finder)
- [ ] `/research topic` runs standard subagent workflow with no team behavior
- [ ] `/research-deep --swarm topic` triggers swarm discovery with agent team
- [ ] `/research-deep topic` runs standard discovery