### PR TITLE
feat: #34 - Enforce vertical TDD workflow with 4-phase process

### DIFF
--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -17,9 +17,24 @@ Complete the task following spec exactly. Operate with fresh context to avoid dr
 
 ## Constraints
 
-**TDD Awareness**: Receive TDD mode: **strict** (must have test, stop if missing), **soft** (warn, proceed), **off** (no checks). When enabled, follow Red-Green-Refactor.
+**TDD Awareness**: Receive TDD mode: **strict** (must have test, stop if missing), **soft** (warn, proceed), **off** (no checks). When enabled, follow the vertical TDD workflow below.
 
 Why strict mode stops: Catching spec drift early is cheaper than debugging later.
+
+**TDD Workflow** (when mode is strict or soft):
+
+1. **Tracer Bullet**: Write ONE test for the highest-priority behavior. Verify it FAILS (RED). Write minimal code to pass (GREEN). Run per-cycle checklist. **STOP after tracer bullet passes** — verify the approach is correct before proceeding.
+2. **Incremental Loop**: For each remaining behavior: write ONE test (RED), write minimal code to pass (GREEN), run per-cycle checklist. **Do NOT generate all tests first. Write ONE test, make it pass, verify checklist, then write the NEXT test.**
+3. **Refactor**: Only when ALL tests are GREEN. One structural change at a time. Run tests after each change.
+
+**Per-Cycle Checklist** (verify after every RED-GREEN pair):
+- [ ] **Behavior, not implementation**: Test describes WHAT the system does, not HOW
+- [ ] **Public interface only**: Test uses the same API as production callers
+- [ ] **Survives refactor**: Would this test break if internals changed but behavior stayed the same?
+- [ ] **Minimal code**: Implementation is the simplest thing that passes — no speculative features
+- [ ] **No horizontal drift**: Did you write only ONE test before implementing?
+
+**Pre-existing RED state**: If existing tests are already failing when you start, note them and proceed with new behavior only. Do not attempt to fix pre-existing failures unless that is the task.
 
 **Focus**: Implement ONLY what the task requires. No extra features, improvements, or unrelated refactoring.
 

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -55,7 +55,11 @@ The default implementation approach uses sequential subagent-driven development 
 ### Subagent Workflow
 You orchestrate; implementer agents execute. Per task:
 
-1. **Dispatch implementer** (Task tool, `subagent_type: "implementer"`): task spec, TDD mode, context, files to reference
+1. **Dispatch implementer** (Task tool, `subagent_type: "implementer"`): task spec, TDD mode, context, files to reference. **When TDD mode is strict or soft**: Before dispatching, read TDD reference files via `Glob("**/tdd/references/*.md", path: "~/.claude/plugins")` and inject key excerpts into the implementer's Task prompt:
+   - From `mocking.md`: boundary-only rule, system boundary definition, legacy compatibility clause
+   - From `test-quality.md`: behavioral test criteria (WHAT not HOW, public interface, survives refactor)
+   - From `interface-design.md`: DI principle (accept dependencies, don't create them)
+   - Inject as literal text under a `TDD GUIDANCE:` section in the prompt. Do NOT include full files — extract the rules and one example each.
 2. **Handle questions**: Answer from plan/context first, else AskUserQuestion
 3. **Dispatch spec-reviewer** (`subagent_type: "spec-reviewer"`): original spec + implementation → verify nothing missing/extra, behavior matches
 4. **Dispatch code-quality-reviewer** (`subagent_type: "code-quality-reviewer"`): changed files → check bugs/smells/security/anti-patterns

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -11,7 +11,7 @@ Correctness > Test Coverage > Implementation Speed
 
 ## Goal
 
-Enforce Test-Driven Development based on project configuration. Agents reliably implement happy-path code that breaks on edge cases — TDD makes the test the durable specification across fresh-context dispatches.
+Enforce Test-Driven Development as a **process**, not just a presence check. Agents left unconstrained write all tests first, then all code (horizontal slicing). This produces tests coupled to implementation that break on refactor. The 4-phase workflow below enforces vertical TDD cycles where each test drives one slice of implementation.
 
 ## Configuration
 
@@ -25,29 +25,106 @@ Check both `CLAUDE.md` and `.claude/CLAUDE.md`. Default: `off`.
 ## Modes
 
 ### Strict (`tdd: strict`)
-Hard enforcement. Before implementation, verify test exists. If missing, STOP and present AskUserQuestion with options: (1) Write test first, (2) Prototype escape with justification. Log escapes for review.
+Full 4-phase workflow with blocking gates. Planning phase requires user confirmation via AskUserQuestion before coding. Each phase has explicit entry/exit criteria.
 
-**Escape when**: Markdown-only changes, config changes, or when mocking exceeds the change's complexity.
+**Escape when**: Markdown-only changes, config changes, or when mocking exceeds the change's complexity. Present AskUserQuestion with: (1) Write test first, (2) Prototype escape with justification. Log escapes.
 
 ### Soft (`tdd: soft`)
-Warning without blocking. Check for test, warn if missing, continue. Summarize untested items after completion.
+Full 4-phase workflow guidance but **no blocking gates**. Planning phase generates and presents the plan but proceeds immediately. Warns on deviations (no test, horizontal slicing) but does not stop. Summarize untested items after completion.
 
 ### Off (`tdd: off`)
 No TDD checks. Standard implementation flow.
 
+## Anti-Pattern: Horizontal Slicing
+
+```
+WRONG (horizontal):               RIGHT (vertical):
+┌──────────────────────┐           ┌──────────────────────┐
+│ Write ALL tests      │           │ Test 1 → Impl 1      │
+│ test1, test2, test3  │           │ ✓ GREEN               │
+├──────────────────────┤           ├──────────────────────┤
+│ Write ALL code       │           │ Test 2 → Impl 2      │
+│ impl1, impl2, impl3 │           │ ✓ GREEN               │
+├──────────────────────┤           ├──────────────────────┤
+│ Hope they match      │           │ Test 3 → Impl 3      │
+│ ✗ Tests are brittle  │           │ ✓ GREEN               │
+└──────────────────────┘           └──────────────────────┘
+```
+
+Horizontal slicing fails because tests written without implementation are based on imagined APIs. They couple to guessed method signatures, mock internal modules, and break on any structural change.
+
+## 4-Phase Workflow
+
+### Phase 1: Planning
+
+**Entry**: Task received with TDD mode strict or soft.
+
+1. Identify the public interface changes needed
+2. List behaviors to test, ordered by priority (core path first, edge cases later)
+3. **Strict mode**: Present interface and behavior list via AskUserQuestion for user confirmation before proceeding
+4. **Soft mode**: Present the plan, proceed immediately
+
+Load reference: `Glob("**/tdd/references/interface-design.md", path: "~/.claude/plugins")`
+
+**Exit**: Confirmed behavior list. Proceed to Tracer Bullet.
+
+**Non-interactive**: If no user response within the current turn, proceed with best judgment and log skipped confirmation.
+
+### Phase 2: Tracer Bullet
+
+Prove one end-to-end path through the system.
+
+1. Write ONE test for the highest-priority behavior
+2. Verify it FAILS (RED) — a passing test before implementation is a false positive
+3. Write minimal implementation to make it pass (GREEN)
+4. Run per-cycle checklist (below)
+5. **Strict mode**: Pause after tracer bullet passes. Present results via AskUserQuestion to confirm before incremental loop.
+
+Load references: `Glob("**/tdd/references/mocking.md", path: "~/.claude/plugins")`, `Glob("**/tdd/references/test-quality.md", path: "~/.claude/plugins")`
+
+**Exit**: One test passing, end-to-end path proven.
+
+### Phase 3: Incremental Loop
+
+For each remaining behavior from the plan:
+
+1. Write ONE test (RED)
+2. Write minimal code to pass (GREEN)
+3. Run per-cycle checklist
+4. Repeat
+
+**Do NOT write the next test until the current cycle is GREEN and the checklist passes.**
+
+### Phase 4: Refactor
+
+Only enter when ALL tests are GREEN.
+
+1. Look for refactoring candidates (duplication, long methods, shallow modules)
+2. Make ONE structural change at a time
+3. Run tests after each change — must stay GREEN
+4. If tests break, revert the refactor
+
+Load reference: `Glob("**/tdd/references/refactoring.md", path: "~/.claude/plugins")`
+
+**Exit**: Clean code, all tests GREEN. Commit test and implementation together.
+
+## Per-Cycle Checklist
+
+After every RED-GREEN pair, verify:
+
+- [ ] **Behavior, not implementation**: Test describes WHAT the system does, not HOW
+- [ ] **Public interface only**: Test uses the same API as production callers
+- [ ] **Survives refactor**: Would this test break if internals changed but behavior stayed the same?
+- [ ] **Minimal code**: Implementation is the simplest thing that passes — no speculative features
+- [ ] **No horizontal drift**: Did you write only ONE test before implementing? If you wrote multiple, STOP and revert to one.
+
+## Pre-Existing RED State
+
+If existing tests are already failing when you start: note them and proceed with new behavior only. Do not attempt to fix pre-existing failures unless that is the task.
+
 ## Test Discovery
 
 Search patterns: `__tests__/[filename].test.ts`, `[filename].test.ts`, `[filename].spec.ts`, `test/[filename].test.ts`, `tests/[filename].test.ts`.
-
-## Red-Green-Refactor Cycle
-
-**Red**: Write test describing expected behavior first and verify it fails — a passing test before implementation is a false positive.
-
-**Green**: Write minimal implementation to pass test — the test defines "done", satisfy it, nothing more.
-
-**Refactor**: Clean up with test safety net — the passing test ensures refactoring doesn't break behavior.
-
-**Commit**: Test and implementation together as atomic unit.
 
 ## Arguments
 

--- a/skills/tdd/references/interface-design.md
+++ b/skills/tdd/references/interface-design.md
@@ -1,0 +1,134 @@
+# Interface Design for Testability
+
+## Three Principles
+
+### 1. Accept Dependencies, Don't Create Them
+
+Functions and classes should receive what they need, not reach out for it.
+
+```typescript
+// HARD TO TEST: creates its own dependencies
+async function processOrder(orderId: string) {
+  const db = new Database(process.env.DATABASE_URL)  // Hidden dependency
+  const order = await db.orders.findById(orderId)
+  const result = await fetch('https://api.payment.com/charge', { ... })  // Hidden dependency
+  return result
+}
+
+// TESTABLE: accepts what it needs
+async function processOrder(
+  orderId: string,
+  orders: OrderRepository,
+  payments: PaymentGateway
+) {
+  const order = await orders.findById(orderId)
+  const result = await payments.charge(order.total)
+  return result
+}
+```
+
+> **Framework note**: React components accept dependencies via props and Context. Server frameworks use constructor injection (NestJS, Angular) or middleware patterns (Hono, Express). The principle is universal.
+
+### 2. Return Results, Don't Produce Side Effects
+
+Prefer returning values over mutating state or triggering side effects.
+
+```typescript
+// SIDE EFFECTS: hard to verify, order-dependent
+function validateUser(user: User) {
+  if (!user.email) {
+    logger.error('Missing email')       // Side effect
+    metrics.increment('validation.fail') // Side effect
+    throw new ValidationError('Email required')
+  }
+  user.validated = true  // Mutation
+}
+
+// PURE RETURN: easy to test, composable
+function validateUser(user: User): ValidationResult {
+  if (!user.email) {
+    return { valid: false, errors: ['Email required'] }
+  }
+  return { valid: true, data: { ...user, validated: true } }
+}
+
+// Caller handles side effects at the boundary
+const result = validateUser(input)
+if (!result.valid) {
+  logger.error('Validation failed', result.errors)
+  metrics.increment('validation.fail')
+}
+```
+
+### 3. Small Surface Area
+
+Expose the minimum interface needed. Hide implementation details.
+
+```typescript
+// TOO MUCH SURFACE: tests couple to internal structure
+class UserCache {
+  public cache: Map<string, User> = new Map()  // Exposed internal
+  public ttl: number = 300                       // Exposed config
+  public lastCleanup: Date = new Date()          // Exposed state
+
+  get(id: string): User | undefined { ... }
+  set(id: string, user: User): void { ... }
+  cleanup(): void { ... }                        // Exposed internal operation
+}
+
+// MINIMAL SURFACE: tests use the same interface as production code
+class UserCache {
+  constructor(private options: { ttlSeconds: number }) {}
+
+  get(id: string): User | undefined { ... }
+  set(id: string, user: User): void { ... }
+  // cleanup is internal — triggered automatically, not part of the API
+}
+```
+
+## Deep Modules
+
+A deep module has a **simple interface** that hides **complex implementation**. This is the key to both good design and testability.
+
+```
+┌─────────────────────────────────────────┐
+│         Shallow Module (avoid)          │
+│                                         │
+│  ┌───────────────────────────────────┐  │
+│  │     Large, complex interface      │  │
+│  │  get() set() delete() cleanup()   │  │
+│  │  configure() validate() reset()   │  │
+│  └───────────────────────────────────┘  │
+│  ┌───────────────────────────────────┐  │
+│  │   Thin implementation             │  │
+│  └───────────────────────────────────┘  │
+└─────────────────────────────────────────┘
+
+┌─────────────────────────────────────────┐
+│          Deep Module (prefer)           │
+│                                         │
+│       ┌───────────────────┐             │
+│       │  Small interface  │             │
+│       │   get()  set()    │             │
+│       └───────────────────┘             │
+│  ┌───────────────────────────────────┐  │
+│  │                                   │  │
+│  │   Rich implementation handles     │  │
+│  │   caching, validation, cleanup,   │  │
+│  │   concurrency, error recovery     │  │
+│  │                                   │  │
+│  └───────────────────────────────────┘  │
+└─────────────────────────────────────────┘
+```
+
+Deep modules are testable because:
+- **Small interface** = few test scenarios to cover
+- **Hidden complexity** = implementation can change without breaking tests
+- **Clear contract** = tests verify WHAT, not HOW
+
+> Concept from "A Philosophy of Software Design" by John Ousterhout.
+
+## See Also
+
+- `references/mocking.md` — boundary-only mocking patterns using DI
+- `references/test-quality.md` — behavioral test criteria

--- a/skills/tdd/references/mocking.md
+++ b/skills/tdd/references/mocking.md
@@ -1,0 +1,107 @@
+# Mocking Policy: Boundary Only
+
+## Rule
+
+Mock at **system boundaries** only. Never mock your own classes or modules.
+
+## What Is a System Boundary?
+
+Anything outside your package that you don't control:
+
+- **External APIs** (HTTP services, third-party SDKs)
+- **Databases** (queries, connections)
+- **OS services** (filesystem, network, timers)
+- **Randomness and time** (`Date.now()`, `Math.random()`, `crypto`)
+
+**Monorepo clause**: Another team's package is a boundary. Your own modules within the same package are NOT.
+
+## Why Not Mock Internals?
+
+Internal mocks couple tests to implementation. When you refactor (rename a method, extract a class, change data flow), every mock breaks — even if behavior is unchanged. This makes tests an obstacle to improvement rather than a safety net.
+
+## Patterns
+
+### Dependency Injection
+
+Pass dependencies instead of importing them:
+
+```typescript
+// WRONG: Hardcoded dependency — must mock module to test
+class OrderService {
+  async place(order: Order) {
+    const payment = await stripe.charges.create(order.total) // Coupled to Stripe
+    await db.orders.insert({ ...order, paymentId: payment.id }) // Coupled to DB
+  }
+}
+
+// RIGHT: Inject boundaries — test with fakes, run with real implementations
+class OrderService {
+  constructor(
+    private payments: PaymentGateway,  // Interface, not Stripe
+    private orders: OrderRepository     // Interface, not DB
+  ) {}
+
+  async place(order: Order) {
+    const payment = await this.payments.charge(order.total)
+    await this.orders.save({ ...order, paymentId: payment.id })
+  }
+}
+
+// Test: inject fakes for boundaries
+function setup() {
+  const payments: PaymentGateway = { charge: vi.fn().mockResolvedValue({ id: 'pay_1' }) }
+  const orders: OrderRepository = { save: vi.fn().mockResolvedValue(undefined) }
+  const service = new OrderService(payments, orders)
+  return { service, payments, orders }
+}
+```
+
+> **Framework note**: In React, use Context or props for DI. In Angular, use the DI container. In Go, pass interfaces. The principle is the same: accept dependencies, don't create them.
+
+### SDK-Style Interface
+
+Wrap external SDKs behind your own interface:
+
+```typescript
+// Define YOUR interface for what you need
+interface EmailSender {
+  send(to: string, subject: string, body: string): Promise<void>
+}
+
+// Production: real SDK
+class SendGridEmailSender implements EmailSender {
+  constructor(private client: SendGridClient) {}
+  async send(to: string, subject: string, body: string) {
+    await this.client.send({ to, subject, html: body })
+  }
+}
+
+// Test: fake implementation (not a mock of SendGrid internals)
+class FakeEmailSender implements EmailSender {
+  sent: Array<{ to: string; subject: string; body: string }> = []
+  async send(to: string, subject: string, body: string) {
+    this.sent.push({ to, subject, body })
+  }
+}
+
+// Test reads naturally — no mock assertions
+test('sends welcome email after signup', async () => {
+  const emails = new FakeEmailSender()
+  const auth = new AuthService(emails)
+
+  await auth.signup('user@example.com', 'password')
+
+  expect(emails.sent).toEqual([
+    { to: 'user@example.com', subject: 'Welcome', body: expect.stringContaining('Welcome') }
+  ])
+})
+```
+
+## Legacy Compatibility
+
+When working in a codebase that already mocks internal modules (e.g., `vi.mock('./utils')`, `jest.mock('../services/foo')`), **follow the repo's existing conventions** unless explicitly asked to refactor the testing approach. The boundary-only policy is a best practice for new code, not a mandate to rewrite existing tests.
+
+## See Also
+
+- `references/interface-design.md` — DI and testability principles
+- `references/test-quality.md` — behavioral test criteria

--- a/skills/tdd/references/refactoring.md
+++ b/skills/tdd/references/refactoring.md
@@ -1,0 +1,77 @@
+# Refactoring in TDD
+
+## Golden Rule
+
+**Never refactor while RED.** All tests must pass before you change structure. Refactoring means changing design without changing behavior — a failing test means behavior is undefined.
+
+## When to Refactor
+
+Refactor after a GREEN cycle when you notice any of these candidates:
+
+### 1. Duplication
+
+Same logic in two or more places. Extract to a shared function or module.
+
+```
+Signal: Copy-pasted code blocks, similar conditionals in multiple functions
+Action: Extract common logic into a named function
+```
+
+### 2. Long Methods
+
+A function doing more than one thing. Extract steps into named functions.
+
+```
+Signal: Function > 20 lines, multiple levels of indentation, comments explaining sections
+Action: Extract each section into a function named after what it does
+```
+
+### 3. Shallow Modules
+
+Class or module with large surface area but thin implementation. Consolidate the interface.
+
+```
+Signal: Many public methods that each do very little, lots of getters/setters
+Action: Reduce public API to what callers actually need
+```
+
+### 4. Feature Envy
+
+A function that uses more data from another module than its own. Move it closer to the data.
+
+```
+Signal: Function accesses 3+ properties of another object, chains of property access
+Action: Move the function to the module whose data it primarily uses
+```
+
+### 5. Primitive Obsession
+
+Using primitive types (strings, numbers) where a domain type would be clearer.
+
+```
+Signal: String parameters named "email", "url", "currency", validation scattered across callers
+Action: Create a value object (e.g., Email, URL, Money) that validates on construction
+```
+
+### 6. Code Revealed as Problematic
+
+Existing code that wasn't obviously bad until the new feature exposed its weakness.
+
+```
+Signal: New feature requires awkward workarounds, existing abstraction doesn't fit
+Action: Refactor the existing code to accommodate the new pattern cleanly
+```
+
+## Process
+
+1. Confirm all tests are GREEN
+2. Make ONE structural change
+3. Run tests — they must stay GREEN
+4. If tests break, revert the refactor (behavior changed, not just structure)
+5. Repeat from step 2 for the next change
+
+Small steps. Each refactor is independently revertible.
+
+## See Also
+
+- `references/test-quality.md` — tests that survive refactors

--- a/skills/tdd/references/test-quality.md
+++ b/skills/tdd/references/test-quality.md
@@ -1,0 +1,144 @@
+# Behavioral Test Quality
+
+## Core Principle
+
+A good test describes **what the system does**, not **how it does it**. Tests are specifications — they should read like a behavior contract.
+
+## Good Tests
+
+### Verify Behavior Through Public Interfaces
+
+```typescript
+// GOOD: Tests observable behavior through the public API
+test('registered user can log in with correct password', async () => {
+  const { auth } = setup()
+
+  await auth.register('user@test.com', 'secret123')
+  const session = await auth.login('user@test.com', 'secret123')
+
+  expect(session.userId).toBeDefined()
+  expect(session.expiresAt).toBeInstanceOf(Date)
+})
+```
+
+### Read Like a Specification
+
+```typescript
+// GOOD: Test name + body tells you the business rule
+test('order total includes tax for taxable items', () => {
+  const { cart } = setup()
+
+  cart.add({ name: 'Book', price: 20, taxable: true })
+  cart.add({ name: 'Gift Card', price: 50, taxable: false })
+
+  expect(cart.total()).toBe(71.60) // 20 * 1.08 + 50
+})
+```
+
+### Survive Refactors
+
+```typescript
+// GOOD: This test passes whether you use a Map, object, array,
+// Redis, or SQLite internally — it only cares about behavior
+test('cached value is returned on second call', async () => {
+  const { cache, fetchCount } = setup()
+
+  await cache.get('key')
+  await cache.get('key')
+
+  expect(fetchCount()).toBe(1) // Fetched once, cached second time
+})
+```
+
+## Bad Tests (Before/After)
+
+### Coupled to Implementation
+
+```typescript
+// BAD: Tests HOW, not WHAT — breaks if you rename the method or change data flow
+test('calls userRepository.findByEmail', async () => {
+  const repo = { findByEmail: vi.fn().mockResolvedValue(mockUser) }
+  const service = new AuthService(repo)
+
+  await service.login('user@test.com', 'pass')
+
+  expect(repo.findByEmail).toHaveBeenCalledWith('user@test.com') // Implementation detail
+})
+
+// BETTER: Tests the outcome
+test('returns user session for valid credentials', async () => {
+  const { auth } = setupWithUser('user@test.com', 'pass')
+
+  const session = await auth.login('user@test.com', 'pass')
+
+  expect(session.userId).toBeDefined()
+})
+```
+
+### Mock Internal Collaborators
+
+```typescript
+// BAD: Mocking your own module — test breaks when you refactor internals
+vi.mock('./utils/hash', () => ({ hashPassword: vi.fn(() => 'hashed') }))
+vi.mock('./services/email', () => ({ sendWelcome: vi.fn() }))
+
+test('registers user', async () => {
+  await register('user@test.com', 'pass')
+  expect(hashPassword).toHaveBeenCalledWith('pass')  // Internal detail
+  expect(sendWelcome).toHaveBeenCalledWith('user@test.com')  // Internal detail
+})
+
+// BETTER: Test through the public interface, mock only boundaries
+test('registered user receives welcome email', async () => {
+  const { auth, emails } = setup()  // emails is a boundary fake
+
+  await auth.register('user@test.com', 'pass')
+
+  expect(emails.sent).toContainEqual(
+    expect.objectContaining({ to: 'user@test.com', subject: 'Welcome' })
+  )
+})
+```
+
+### Test Private Methods
+
+```typescript
+// BAD: Accessing internals to test them directly
+test('_normalizeEmail lowercases and trims', () => {
+  const service = new AuthService()
+  // @ts-expect-error accessing private method
+  expect(service._normalizeEmail(' User@Test.COM ')).toBe('user@test.com')
+})
+
+// BETTER: Test the behavior that USES normalization
+test('login works regardless of email casing', async () => {
+  const { auth } = setupWithUser('user@test.com', 'pass')
+
+  const session = await auth.login(' User@TEST.com ', 'pass')
+
+  expect(session.userId).toBeDefined()
+})
+```
+
+> **Framework note**: In React, test component behavior (render output, user interactions, callbacks) not internal state. In API handlers, test request/response, not middleware internals.
+
+## Test Naming
+
+Name tests after WHAT happens, not HOW:
+
+```typescript
+// GOOD — describes behavior
+test('returns null when user not found', () => {})
+test('throws ValidationError for empty email', () => {})
+test('expires session after 30 minutes of inactivity', () => {})
+
+// BAD — describes implementation
+test('calls findById with the user ID', () => {})
+test('checks email length > 0', () => {})
+test('uses setTimeout for session timeout', () => {})
+```
+
+## See Also
+
+- `references/mocking.md` — when and how to mock
+- `references/interface-design.md` — designing for testability

--- a/skills/test/references/test-patterns.md
+++ b/skills/test/references/test-patterns.md
@@ -53,12 +53,15 @@ test('throws error for invalid input', () => {
   expect(() => instance.process('')).toThrow('Input required')
 })
 
-test('calls dependency with correct arguments', () => {
-  const { instance, mockDependency } = setup()
+// Mock assertions are appropriate for SYSTEM BOUNDARY dependencies
+// (external APIs, databases, third-party SDKs) — not internal modules.
+// See: skills/tdd/references/mocking.md for boundary-only mocking policy.
+test('calls payment gateway with correct amount', () => {
+  const { instance, mockPaymentGateway } = setup()
 
-  instance.doWork()
+  instance.processOrder()
 
-  expect(mockDependency).toHaveBeenCalledWith('expected-arg')
+  expect(mockPaymentGateway).toHaveBeenCalledWith('expected-arg')
 })
 ```
 


### PR DESCRIPTION
## Summary

Closes #34

- Replace simple TDD presence-check with structured 4-phase vertical workflow (Planning → Tracer Bullet → Incremental Loop → Refactor) that prevents horizontal slicing
- Add per-cycle checklist enforcing behavioral tests, public interface testing, and minimal implementation
- Add 4 reference documents: mocking policy (boundary-only), interface design (DI), test quality (behavioral), refactoring guidance
- Update implementer agent to receive TDD workflow instructions and inject reference excerpts into subagent prompts
- Align test-patterns example with boundary-only mocking policy

## Test plan

- [ ] Invoke `/implement` with `tdd: strict` in CLAUDE.md and verify implementer follows vertical TDD (one test → one impl per cycle)
- [ ] Verify tracer bullet phase pauses for confirmation in strict mode
- [ ] Verify `tdd: soft` proceeds without blocking gates
- [ ] Verify `tdd: off` skips all TDD checks
- [ ] Confirm reference files load correctly via `Glob("**/tdd/references/*.md", path: "~/.claude/plugins")`