### PR TITLE
chore: release v1.19.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations for enhanced software development workflow",
   "author": {
     "name": "Ladislav Martincik",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the SDLC Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.0] - 2026-02-12
+
+### Added
+
+- **4-phase vertical TDD workflow** — Planning → Tracer Bullet → Incremental Loop → Refactor, replacing simple presence-check enforcement
+- **Per-cycle checklist** — behavioral tests, public interface only, survives refactor, minimal code, no horizontal drift
+- **TDD reference documents** — mocking policy (boundary-only), interface design (DI), test quality (behavioral), refactoring guidance
+- **TDD reference injection** — `/implement` now injects key TDD excerpts into implementer subagent prompts when TDD mode is strict or soft
+
+### Changed
+
+- **`skills/tdd/SKILL.md`** — rewritten with anti-pattern documentation (horizontal vs vertical slicing) and explicit phase entry/exit criteria
+- **`agents/implementer.md`** — vertical TDD workflow instructions with per-cycle checklist
+- **`skills/test/references/test-patterns.md`** — mock example aligned with boundary-only policy
+
 ## [1.18.1] - 2026-02-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-plugin",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump to v1.19.0 for release. Merge to trigger release.

### What's in v1.19.0

- **4-phase vertical TDD workflow** — Planning → Tracer Bullet → Incremental Loop → Refactor (#34)
- **Per-cycle checklist** — behavioral tests, public interface only, survives refactor, minimal code
- **TDD reference documents** — mocking policy, interface design, test quality, refactoring guidance
- **TDD reference injection** into implementer subagent prompts

## Test plan

- [x] `bun run validate` passes (versions synchronized: 1.19.0)
- [x] CHANGELOG.md updated with actual changes
- [x] Only release files changed (package.json, plugin.json, CHANGELOG.md)