### PR TITLE
chore: release v1.21.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations for enhanced software development workflow",
   "author": {
     "name": "Ladislav Martincik",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the SDLC Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.0] - 2026-02-14
+
+### Changed
+
+- **Mandatory web search** in `/research`, `/research-deep`, and `/plan` — web-search-researcher now always spawns in parallel with codebase subagents instead of only when explicitly requested
+- **Parallel search strategy** in web-search-researcher agent — calls `mcp__search__search_web` and `WebSearch` in parallel instead of sequential Sonar-first flow
+- **Graceful degradation** — all commands complete even when search APIs are unavailable; explicit partial and total failure handling in the agent
+
 ## [1.20.0] - 2026-02-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-plugin",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version from 1.20.0 to 1.21.0 in `package.json` and `plugin.json`
- Add changelog entry for mandatory web search integration

## Test plan

- [x] `bun run validate` passes