### PR TITLE
feat: #55 - Integrate AI coding discipline rules + DDIA probes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations for enhanced software development workflow",
   "author": {
     "name": "Ladislav Martincik",

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -24,3 +24,9 @@ jobs:
 
       - name: Validate plugin (versions, schema, docs)
         run: bun run validate
+
+      - name: Type-check
+        run: bunx tsc --noEmit
+
+      - name: Run tests
+        run: bun test

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,10 @@ research/
 # Test outputs
 test-results/
 playwright-report/
+eval/results/
+
+# Desloppify working state
+.desloppify/
 
 # x-search data (cache and watchlist are local runtime data)
 utils/x-search/data/cache/*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to the SDLC Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.28.0] - 2026-04-13
+
+### Added
+- AI coding discipline rules in implementer agent self-review (silent fallbacks, boundary-only catch, lookup tables, debug log preservation)
+- "No lookup tables" check in TDD per-cycle checklists (implementer + TDD skill)
+- DDIA probes with relevance gate in blindspot review protocol (replication, partitioning, isolation, error boundaries)
+- 2 new Tier 3 production failure probes (default value masking, hardcoded lookup tables)
+- 3 new anti-pattern categories in code-quality-reviewer
+- CI now runs type-checking and unit tests (previously only plugin validation)
+- 109 new unit tests across 7 test files (release, validate-versions, validate-plugin, run-eval, cache, format)
+- `test` script in package.json
+
+### Changed
+- Scoring rubric error handling examples updated to promote boundary-only catching at all 4 levels
+- search-mcp: `startServer()` decomposed into `handleSearchRequest()` + orchestration
+- search-mcp: exhaustive switch default in provider dispatch
+- search-mcp/brave: `result_filter` from BraveOptions now applied to HTTP request
+- search-mcp/brave: timeout configurable via `deps.timeoutMs` (was hardcoded 30s)
+- eval: `runEval()` decomposed into `runCase()` + `generateReport()`
+- x-search: `TwitterUser` interface replaces `any` in profile/format
+
+### Fixed
+- Eval harness now emits synthetic failed result on case execution errors (was silently passing)
+- `formatProfileTelegram` shows "metrics unavailable" instead of fake zeros when `public_metrics` absent
+- `thread()` catch typing improved from `any` to `unknown`
+- `release.ts` JSON.parse guarded with try/catch
+- Pre-existing type errors in resolve-models.test.ts and brave.test.ts
+
 ## [1.27.1] - 2026-04-10
 
 ### Changed

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,21 @@
+# TODOs
+
+## Standalone coding-discipline skill
+Why: If the embed-in-agents approach proves insufficient (agents skip checklist items), a standalone skill loaded via trigger words would provide stronger enforcement.
+Context: The ai-coding-principles repo (luoling8192/ai-coding-principles) packages rules as a standalone skill. We chose embed-in-agents for minimality, but this is the fallback.
+Dependencies: Evidence that the advisory checklist is being ignored by agents.
+
+## Full DDIA reference skill for /plan
+Why: Targeted DDIA probes in blindspot review cover common cases, but a full reference skill would enable deeper system design guidance during planning.
+Context: The ai-coding-principles repo has a 400+ line DDIA distilled reference. We could install it directly or create our own adapted version.
+Dependencies: User feedback that targeted probes are insufficient for data-intensive planning.
+
+## Scenario-based enforcement verification
+Why: Current manual test plan only verifies text presence, not whether agents actually catch violations (Codex finding #3).
+Context: LLM behavior testing is non-deterministic. Need a skill evaluation framework with representative scenarios and pass/fail criteria.
+Dependencies: Skill evaluation framework infrastructure.
+
+## Blocking discipline gate for /implement
+Why: If advisory checklist proves insufficient, a blocking gate (like the de-slop gate pattern) would provide stronger enforcement with "fix now or later?" prompt.
+Context: Decided against for initial implementation to minimize disruption. De-slop gate at commands/implement.md:266-274 is the template.
+Dependencies: Evidence that advisory approach has low compliance.

--- a/agents/code-quality-reviewer.md
+++ b/agents/code-quality-reviewer.md
@@ -26,7 +26,7 @@ Quick sanity check for obvious issues before further workflow stages. Catch clea
 
 **Code smells**: functions >100 lines, nesting >4 levels, exact duplicates, magic numbers, unused code
 
-**Anti-patterns**: callback hell, sync I/O in async, swallowed errors, mutated params, global state modification
+**Anti-patterns**: callback hell, sync I/O in async, swallowed errors, mutated params, global state modification, default-value masking of required data (`data.field ?? 0` where field must exist), try/catch inside business logic that returns null/undefined instead of propagating, hardcoded lookup tables (`if (x === 1000) return 100` with 3+ literal branches fitting test data)
 
 ## Output Format
 ### PASS

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -32,6 +32,7 @@ Why strict mode stops: Catching spec drift early is cheaper than debugging later
 - [ ] **Public interface only**: Test uses the same API as production callers
 - [ ] **Survives refactor**: Would this test break if internals changed but behavior stayed the same?
 - [ ] **Minimal code**: Implementation is the simplest thing that passes — no speculative features
+- [ ] **No lookup tables**: Does the implementation compute results algorithmically, or did I hardcode return values that match the test inputs? If `calculateDiscount(1000, 'gold')` returns 100 via an `if` branch rather than `amount * rate`, rewrite it.
 - [ ] **No horizontal drift**: Did you write only ONE test before implementing?
 
 **Pre-existing RED state**: If existing tests are already failing when you start, note them and proceed with new behavior only. Do not attempt to fix pre-existing failures unless that is the task.
@@ -49,6 +50,10 @@ Why scope discipline matters: Scope drift is the #1 failure mode in subagent wor
 - **Basic health**: Does it compile/run without errors?
 - **Test validity** (if TDD mode): Does the test pass? If it fails, the implementation is incomplete.
 - **Clarity**: Are there obvious bugs or typos?
+- **No silent fallbacks**: Did I use `??` or `||` to provide a default for data that should never be missing? Optional config and display placeholders are fine — but required fields must throw, not mask.
+- **Error propagation**: Did I add try/catch inside business logic? Errors should propagate naturally; catch only at system boundaries (API handlers, queue consumers, cron entry points).
+- **No lookup tables**: Does the implementation use real algorithmic logic for all inputs, or did I hardcode values that happen to match the test cases?
+- **Debug log preservation**: If diagnostic logs were added during this investigation, did I leave them untouched? Never remove debug logs in the same commit as a fix — they are separate concerns.
 
 **Commit format**: After implementation, create atomic commit using conventional types:
 

--- a/eval/run-eval.test.ts
+++ b/eval/run-eval.test.ts
@@ -200,8 +200,10 @@ describe("runCase", () => {
       totalCost: 0,
     });
 
-    // File not found → caught, results remain empty
-    expect(result.results).toHaveLength(0);
+    // File not found → caught, synthetic failure result appended
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].passed).toBe(false);
+    expect(result.results[0].assertion).toBe("case_execution");
     expect(result.cost).toBe(0);
   });
 });

--- a/eval/run-eval.test.ts
+++ b/eval/run-eval.test.ts
@@ -1,0 +1,207 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { rateLimit, generateReport, runCase } from "./run-eval.ts";
+import type { EvalResult, EvalCase } from "./eval.types.ts";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// ---------------------------------------------------------------------------
+// rateLimit
+// ---------------------------------------------------------------------------
+
+describe("rateLimit", () => {
+  test("is exported and is a function", () => {
+    expect(typeof rateLimit).toBe("function");
+  });
+
+  test("resolves after the calculated delay", async () => {
+    const start = Date.now();
+    // 60 req/min → 1000 ms delay; use 120 req/min → ~500 ms to keep tests fast
+    await rateLimit(120);
+    const elapsed = Date.now() - start;
+    // Allow generous margin for CI timing jitter
+    expect(elapsed).toBeGreaterThanOrEqual(400);
+  });
+
+  test("delay is inversely proportional to requestsPerMinute", async () => {
+    // 600 req/min → 100 ms
+    const start = Date.now();
+    await rateLimit(600);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(80);
+    expect(elapsed).toBeLessThan(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateReport
+// ---------------------------------------------------------------------------
+
+describe("generateReport", () => {
+  let tmpDir: string;
+
+  // We need to monkey-patch RESULTS_DIR so the report is written to a temp dir.
+  // generateReport uses a module-level RESULTS_DIR constant derived from
+  // import.meta.dir.  Since we can't easily override it without refactoring,
+  // we accept the report is written to eval/results/ and just validate the
+  // return value and report structure via the written JSON.
+
+  test("is exported and is a function", () => {
+    expect(typeof generateReport).toBe("function");
+  });
+
+  test("returns a non-empty report path string", async () => {
+    const results: EvalResult[] = [];
+    const path = await generateReport(results, "structural", 0, 0, 0);
+    expect(typeof path).toBe("string");
+    expect(path.length).toBeGreaterThan(0);
+    expect(path).toContain("eval-");
+    expect(path).toEndWith(".json");
+  });
+
+  test("report path contains the results directory", async () => {
+    const results: EvalResult[] = [];
+    const path = await generateReport(results, "structural", 0, 0, 0);
+    expect(path).toContain("results");
+  });
+
+  test("written report has correct structure for empty results", async () => {
+    const results: EvalResult[] = [];
+    const path = await generateReport(results, "structural", 3, 1, 0);
+
+    const { readFile } = await import("fs/promises");
+    const raw = await readFile(path, "utf-8");
+    const report = JSON.parse(raw);
+
+    expect(report.mode).toBe("structural");
+    expect(report.totalCases).toBe(3);
+    expect(report.totalAssertions).toBe(0);
+    expect(report.passed).toBe(0);
+    expect(report.failed).toBe(0);
+    expect(report.skipped).toBe(1);
+    expect(report.estimatedCost).toBe(0);
+    expect(Array.isArray(report.results)).toBe(true);
+    expect(report.results).toHaveLength(0);
+    expect(typeof report.timestamp).toBe("string");
+    // timestamp must be a valid ISO date
+    expect(Number.isNaN(Date.parse(report.timestamp))).toBe(false);
+  });
+
+  test("counts passed and failed correctly", async () => {
+    const results: EvalResult[] = [
+      { promptFile: "a.md", description: "desc", mode: "structural", assertion: "has title", passed: true },
+      { promptFile: "a.md", description: "desc", mode: "structural", assertion: "has body", passed: false },
+      { promptFile: "b.md", description: "desc2", mode: "structural", assertion: "has footer", passed: true },
+    ];
+    const path = await generateReport(results, "all", 2, 0, 1.23);
+
+    const { readFile } = await import("fs/promises");
+    const report = JSON.parse(await readFile(path, "utf-8"));
+
+    expect(report.totalAssertions).toBe(3);
+    expect(report.passed).toBe(2);
+    expect(report.failed).toBe(1);
+    expect(report.estimatedCost).toBe(1.23);
+    expect(report.results).toHaveLength(3);
+  });
+
+  test("report preserves result details", async () => {
+    const results: EvalResult[] = [
+      {
+        promptFile: "commands/implement.md",
+        description: "implement command",
+        mode: "behavioral",
+        assertion: "mentions TDD",
+        passed: false,
+        details: "Assertion failed",
+      },
+    ];
+    const path = await generateReport(results, "llm", 1, 0, 0.005);
+
+    const { readFile } = await import("fs/promises");
+    const report = JSON.parse(await readFile(path, "utf-8"));
+
+    expect(report.results[0].promptFile).toBe("commands/implement.md");
+    expect(report.results[0].assertion).toBe("mentions TDD");
+    expect(report.results[0].passed).toBe(false);
+    expect(report.results[0].details).toBe("Assertion failed");
+  });
+
+  test("mode is reflected in report", async () => {
+    for (const mode of ["structural", "llm", "all"] as const) {
+      const path = await generateReport([], mode, 0, 0, 0);
+      const { readFile } = await import("fs/promises");
+      const report = JSON.parse(await readFile(path, "utf-8"));
+      expect(report.mode).toBe(mode);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runCase — signature / export verification only (no API calls)
+// ---------------------------------------------------------------------------
+
+describe("runCase", () => {
+  test("is exported and is a function", () => {
+    expect(typeof runCase).toBe("function");
+  });
+
+  test("accepts EvalCase and RunCaseOpts, returns RunCaseResult shape", async () => {
+    // Provide an eval case that references a non-existent prompt file so the
+    // function catches the error internally and returns gracefully without
+    // touching the Anthropic API.
+    const evalCase: EvalCase = {
+      promptFile: "__nonexistent_test_file__.md",
+      description: "signature verification only",
+      structural: [],
+    };
+
+    const result = await runCase(evalCase, {
+      mode: "structural",
+      anthropic: null,
+      totalCost: 0,
+    });
+
+    // Even when the prompt file is missing runCase should return the shape
+    expect(result).toHaveProperty("results");
+    expect(result).toHaveProperty("cost");
+    expect(result).toHaveProperty("skipped");
+    expect(Array.isArray(result.results)).toBe(true);
+    expect(typeof result.cost).toBe("number");
+    expect(typeof result.skipped).toBe("boolean");
+  });
+
+  test("returns skipped=false when no spend guard is triggered", async () => {
+    const evalCase: EvalCase = {
+      promptFile: "__nonexistent__.md",
+      description: "skipped flag check",
+      structural: [],
+    };
+
+    const result = await runCase(evalCase, {
+      mode: "structural",
+      anthropic: null,
+      totalCost: 0,
+    });
+
+    expect(result.skipped).toBe(false);
+  });
+
+  test("structural mode with no assertions returns empty results", async () => {
+    const evalCase: EvalCase = {
+      promptFile: "__nonexistent__.md",
+      description: "empty structural",
+      structural: [],
+    };
+
+    const result = await runCase(evalCase, {
+      mode: "structural",
+      anthropic: null,
+      totalCost: 0,
+    });
+
+    // File not found → caught, results remain empty
+    expect(result.results).toHaveLength(0);
+    expect(result.cost).toBe(0);
+  });
+});

--- a/eval/run-eval.ts
+++ b/eval/run-eval.ts
@@ -201,7 +201,116 @@ async function rateLimit(requestsPerMinute: number) {
   await new Promise(resolve => setTimeout(resolve, delayMs))
 }
 
-// Main eval runner
+interface RunCaseOpts {
+  mode: EvalMode
+  anthropic: Anthropic | null
+  totalCost: number
+}
+
+interface RunCaseResult {
+  results: EvalResult[]
+  cost: number
+  skipped: boolean
+}
+
+// Run a single eval case and return its results, cost, and whether it was skipped
+async function runCase(evalCase: EvalCase, opts: RunCaseOpts): Promise<RunCaseResult> {
+  const { mode, anthropic, totalCost } = opts
+  const caseResults: EvalResult[] = []
+  let caseCost = 0
+
+  console.log(`Testing: ${evalCase.promptFile}`)
+  console.log(`  ${evalCase.description}`)
+
+  try {
+    // Read prompt content
+    const content = await readPromptFile(evalCase.promptFile)
+
+    // Run structural assertions
+    if (mode === 'structural' || mode === 'all') {
+      const structuralResults = runStructuralAssertions(evalCase, content)
+      caseResults.push(...structuralResults)
+
+      const passed = structuralResults.filter(r => r.passed).length
+      const failed = structuralResults.filter(r => !r.passed).length
+      console.log(`  Structural: ${passed} passed, ${failed} failed`)
+    }
+
+    // Run behavioral assertions
+    if ((mode === 'llm' || mode === 'all') && anthropic && evalCase.behavioral) {
+      // Check spend guard
+      if (totalCost >= config.maxSpendPerRun) {
+        console.warn(`  ⚠️  Spend limit reached ($${config.maxSpendPerRun}). Skipping LLM eval.`)
+        console.log()
+        return { results: caseResults, cost: 0, skipped: true }
+      }
+
+      // Rate limit
+      await rateLimit(config.maxRequestsPerMinute)
+
+      const { results: behavioralResults, cost } = await runBehavioralAssertions(
+        evalCase,
+        content,
+        anthropic
+      )
+      caseResults.push(...behavioralResults)
+      caseCost = cost
+
+      const passed = behavioralResults.filter(r => r.passed).length
+      const failed = behavioralResults.filter(r => !r.passed).length
+      console.log(`  Behavioral: ${passed} passed, ${failed} failed (cost: $${cost.toFixed(4)})`)
+    }
+  } catch (error) {
+    console.error(`  ✗ Error: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  console.log()
+  return { results: caseResults, cost: caseCost, skipped: false }
+}
+
+// Format and persist the eval report, returning the path it was written to
+async function generateReport(
+  results: EvalResult[],
+  mode: EvalMode,
+  totalCases: number,
+  skippedCount: number,
+  totalCost: number
+): Promise<string> {
+  const report: EvalReport = {
+    timestamp: new Date().toISOString(),
+    mode,
+    totalCases,
+    totalAssertions: results.length,
+    passed: results.filter(r => r.passed).length,
+    failed: results.filter(r => !r.passed).length,
+    skipped: skippedCount,
+    estimatedCost: totalCost,
+    results
+  }
+
+  // Write report to results directory
+  await mkdir(RESULTS_DIR, { recursive: true })
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const reportPath = join(RESULTS_DIR, `eval-${timestamp}.json`)
+  const { writeFile } = await import('fs/promises')
+  await writeFile(reportPath, JSON.stringify(report, null, 2))
+
+  // Print summary
+  console.log('=== Summary ===')
+  console.log(`Total cases: ${report.totalCases}`)
+  console.log(`Total assertions: ${report.totalAssertions}`)
+  console.log(`Passed: ${report.passed}`)
+  console.log(`Failed: ${report.failed}`)
+  console.log(`Skipped: ${report.skipped}`)
+  if (totalCost > 0) {
+    console.log(`Estimated cost: $${totalCost.toFixed(4)}`)
+  }
+  console.log(`\nReport saved to: ${reportPath}\n`)
+
+  return reportPath
+}
+
+// Main eval runner — arg parsing, case loading, orchestration, exit code
 async function runEval() {
   const { mode, filter } = parseArgs()
 
@@ -234,95 +343,22 @@ async function runEval() {
     }
   }
 
-  // Run evals
+  // Run evals case-by-case
   const allResults: EvalResult[] = []
   let totalCost = 0
   let skippedCount = 0
 
   for (const evalCase of cases) {
-    console.log(`Testing: ${evalCase.promptFile}`)
-    console.log(`  ${evalCase.description}`)
-
-    try {
-      // Read prompt content
-      const content = await readPromptFile(evalCase.promptFile)
-
-      // Run structural assertions
-      if (mode === 'structural' || mode === 'all') {
-        const structuralResults = runStructuralAssertions(evalCase, content)
-        allResults.push(...structuralResults)
-
-        const passed = structuralResults.filter(r => r.passed).length
-        const failed = structuralResults.filter(r => !r.passed).length
-        console.log(`  Structural: ${passed} passed, ${failed} failed`)
-      }
-
-      // Run behavioral assertions
-      if ((mode === 'llm' || mode === 'all') && anthropic && evalCase.behavioral) {
-        // Check spend guard
-        if (totalCost >= config.maxSpendPerRun) {
-          console.warn(`  ⚠️  Spend limit reached ($${config.maxSpendPerRun}). Skipping LLM eval.`)
-          skippedCount++
-          continue
-        }
-
-        // Rate limit
-        await rateLimit(config.maxRequestsPerMinute)
-
-        const { results: behavioralResults, cost } = await runBehavioralAssertions(
-          evalCase,
-          content,
-          anthropic
-        )
-        allResults.push(...behavioralResults)
-        totalCost += cost
-
-        const passed = behavioralResults.filter(r => r.passed).length
-        const failed = behavioralResults.filter(r => !r.passed).length
-        console.log(`  Behavioral: ${passed} passed, ${failed} failed (cost: $${cost.toFixed(4)})`)
-      }
-
-    } catch (error) {
-      console.error(`  ✗ Error: ${error instanceof Error ? error.message : String(error)}`)
-    }
-
-    console.log()
+    const { results, cost, skipped } = await runCase(evalCase, { mode, anthropic, totalCost })
+    allResults.push(...results)
+    totalCost += cost
+    if (skipped) skippedCount++
   }
 
-  // Generate report
-  const report: EvalReport = {
-    timestamp: new Date().toISOString(),
-    mode,
-    totalCases: cases.length,
-    totalAssertions: allResults.length,
-    passed: allResults.filter(r => r.passed).length,
-    failed: allResults.filter(r => !r.passed).length,
-    skipped: skippedCount,
-    estimatedCost: totalCost,
-    results: allResults
-  }
+  // Generate and persist the report, then decide exit code
+  await generateReport(allResults, mode, cases.length, skippedCount, totalCost)
 
-  // Write report to results directory
-  await mkdir(RESULTS_DIR, { recursive: true })
-  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
-  const reportPath = join(RESULTS_DIR, `eval-${timestamp}.json`)
-  const { writeFile } = await import('fs/promises')
-  await writeFile(reportPath, JSON.stringify(report, null, 2))
-
-  // Print summary
-  console.log('=== Summary ===')
-  console.log(`Total cases: ${report.totalCases}`)
-  console.log(`Total assertions: ${report.totalAssertions}`)
-  console.log(`Passed: ${report.passed}`)
-  console.log(`Failed: ${report.failed}`)
-  console.log(`Skipped: ${report.skipped}`)
-  if (totalCost > 0) {
-    console.log(`Estimated cost: $${totalCost.toFixed(4)}`)
-  }
-  console.log(`\nReport saved to: ${reportPath}\n`)
-
-  // Exit with failure if any assertions failed
-  if (report.failed > 0) {
+  if (allResults.filter(r => !r.passed).length > 0) {
     process.exit(1)
   }
 }

--- a/eval/run-eval.ts
+++ b/eval/run-eval.ts
@@ -264,9 +264,10 @@ export async function runCase(evalCase: EvalCase, opts: RunCaseOpts): Promise<Ru
     console.error(`  ✗ Error: ${error instanceof Error ? error.message : String(error)}`)
     // Append a synthetic failed result so the harness exits non-zero
     caseResults.push({
-      case: evalCase.promptFile,
+      promptFile: evalCase.promptFile,
+      description: evalCase.description,
       assertion: 'case_execution',
-      type: 'structural',
+      mode: 'structural',
       passed: false,
       details: `Case failed to execute: ${error instanceof Error ? error.message : String(error)}`
     })

--- a/eval/run-eval.ts
+++ b/eval/run-eval.ts
@@ -196,7 +196,7 @@ async function runBehavioralAssertions(
 }
 
 // Rate limiter
-async function rateLimit(requestsPerMinute: number) {
+export async function rateLimit(requestsPerMinute: number) {
   const delayMs = (60 * 1000) / requestsPerMinute
   await new Promise(resolve => setTimeout(resolve, delayMs))
 }
@@ -214,7 +214,7 @@ interface RunCaseResult {
 }
 
 // Run a single eval case and return its results, cost, and whether it was skipped
-async function runCase(evalCase: EvalCase, opts: RunCaseOpts): Promise<RunCaseResult> {
+export async function runCase(evalCase: EvalCase, opts: RunCaseOpts): Promise<RunCaseResult> {
   const { mode, anthropic, totalCost } = opts
   const caseResults: EvalResult[] = []
   let caseCost = 0
@@ -269,7 +269,7 @@ async function runCase(evalCase: EvalCase, opts: RunCaseOpts): Promise<RunCaseRe
 }
 
 // Format and persist the eval report, returning the path it was written to
-async function generateReport(
+export async function generateReport(
   results: EvalResult[],
   mode: EvalMode,
   totalCases: number,
@@ -363,8 +363,10 @@ async function runEval() {
   }
 }
 
-// Run the eval
-runEval().catch(error => {
-  console.error('Fatal error:', error)
-  process.exit(1)
-})
+// Run the eval only when executed directly (not when imported for tests)
+if (import.meta.main) {
+  runEval().catch(error => {
+    console.error('Fatal error:', error)
+    process.exit(1)
+  })
+}

--- a/eval/run-eval.ts
+++ b/eval/run-eval.ts
@@ -262,6 +262,14 @@ export async function runCase(evalCase: EvalCase, opts: RunCaseOpts): Promise<Ru
     }
   } catch (error) {
     console.error(`  ✗ Error: ${error instanceof Error ? error.message : String(error)}`)
+    // Append a synthetic failed result so the harness exits non-zero
+    caseResults.push({
+      case: evalCase.promptFile,
+      assertion: 'case_execution',
+      type: 'structural',
+      passed: false,
+      details: `Case failed to execute: ${error instanceof Error ? error.message : String(error)}`
+    })
   }
 
   console.log()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-plugin",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "test": "bun test",
     "eval": "bun run eval/run-eval.ts --mode structural",
     "eval:llm": "bun run eval/run-eval.ts --mode all",
     "eval:baseline": "bun run eval/run-eval.ts --mode structural && cp eval/results/$(ls -t eval/results/ | head -1) eval/results/baseline/structural-baseline.json",

--- a/references/blindspot-review-protocol.md
+++ b/references/blindspot-review-protocol.md
@@ -26,6 +26,12 @@ Focus on finding what the plan author may have MISSED:
 - Testing gaps (untested paths, missing integration scenarios)
 - Sequence issues (steps in wrong order, missing prerequisites)
 
+If this plan involves databases, replication, partitioning, distributed state, or event streaming, also check:
+- Is the replication strategy appropriate for the consistency requirements?
+- Are partition/shard keys chosen to avoid hotspots?
+- Is the isolation level sufficient for the concurrency model?
+- Are error handling boundaries defined? (catch at API edge, not in business logic)
+
 DO NOT:
 - Suggest general improvements or best practices
 - Critique writing style
@@ -62,6 +68,12 @@ Focus on finding what the plan author may have MISSED:
 - Scope creep signals (does this touch more than intended?)
 - Testing gaps (untested paths, missing integration scenarios)
 - Sequence issues (steps in wrong order, missing prerequisites)
+
+If this plan involves databases, replication, partitioning, distributed state, or event streaming, also check:
+- Is the replication strategy appropriate for the consistency requirements?
+- Are partition/shard keys chosen to avoid hotspots?
+- Is the isolation level sufficient for the concurrency model?
+- Are error handling boundaries defined? (catch at API edge, not in business logic)
 
 DO NOT:
 - Suggest general improvements or best practices

--- a/references/production-failure-patterns.md
+++ b/references/production-failure-patterns.md
@@ -47,6 +47,8 @@ Fixable in the code itself, usually 1-5 lines, but models miss them because the 
 | **DNS/timeout cascade** | "If the upstream service is slow (not down), does this service back up? Is there a timeout? Does it shed load or block all workers?" | http client, fetch, axios, request, got, timeout not set, no AbortController |
 | **Log-and-throw antipattern** | "Is the same error logged at multiple levels as it propagates up the call stack?" | logger.error + throw, console.error + throw, log then rethrow |
 | **Resource leak on error path** | "If an error occurs after acquiring this resource (file handle, connection, stream), is it still released?" | open + close, acquire + release, createReadStream, try without finally |
+| **Default value masking** | "Does this `??` / `||` / default value hide data that should never be missing? Would a thrown error reveal an upstream bug faster?" | `?? 0`, `?? ""`, `?? []`, `\|\| ""`, `\|\| 0`, `?? "Unknown"`, getOrDefault |
+| **Hardcoded lookup table** | "Is this implementation hardcoding specific values instead of computing results algorithmically? Would it produce correct results for inputs NOT in the test suite?" | `if (x === <literal>) return <literal>`, switch with literal returns, hardcoded map matching test values exactly |
 
 ### Probe Generation Rules
 

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -1,0 +1,231 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdir, writeFile, readFile, rm } from "fs/promises";
+import { join } from "path";
+import { bumpVersion, formatDate } from "./release";
+
+// --- bumpVersion ---
+
+describe("bumpVersion", () => {
+  test("increments patch", () => {
+    expect(bumpVersion("1.4.0", "patch")).toBe("1.4.1");
+  });
+
+  test("increments minor and resets patch", () => {
+    expect(bumpVersion("1.4.3", "minor")).toBe("1.5.0");
+  });
+
+  test("increments major and resets minor and patch", () => {
+    expect(bumpVersion("1.4.3", "major")).toBe("2.0.0");
+  });
+
+  test("patch from 0.0.1", () => {
+    expect(bumpVersion("0.0.1", "patch")).toBe("0.0.2");
+  });
+
+  test("minor from 0.1.9 resets patch", () => {
+    expect(bumpVersion("0.1.9", "minor")).toBe("0.2.0");
+  });
+
+  test("major from 0.9.9 resets both", () => {
+    expect(bumpVersion("0.9.9", "major")).toBe("1.0.0");
+  });
+
+  test("major resets minor and patch even when both are non-zero", () => {
+    expect(bumpVersion("3.7.12", "major")).toBe("4.0.0");
+  });
+
+  test("patch preserves major and minor", () => {
+    expect(bumpVersion("2.5.0", "patch")).toBe("2.5.1");
+  });
+});
+
+// --- formatDate ---
+
+describe("formatDate", () => {
+  test("returns a string matching YYYY-MM-DD", () => {
+    expect(formatDate()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test("matches current UTC date", () => {
+    const expected = new Date().toISOString().split("T")[0];
+    expect(formatDate()).toBe(expected);
+  });
+});
+
+// --- release() end-to-end via bun subprocess ---
+//
+// release() is not exported, so we invoke it by spawning bun with the script
+// directly (as the user would). The temp dir is passed as cwd so all file I/O
+// stays isolated from the real repo.
+
+async function setupTempDir(
+  dir: string,
+  opts: {
+    packageVersion?: string;
+    pluginVersion?: string;
+    changelog?: string;
+  } = {}
+): Promise<void> {
+  const pluginDir = join(dir, ".claude-plugin");
+  await mkdir(pluginDir, { recursive: true });
+
+  const pkg = { name: "sdlc-plugin", version: opts.packageVersion ?? "1.4.0" };
+  await writeFile(join(dir, "package.json"), JSON.stringify(pkg, null, 2) + "\n");
+
+  const plugin = { name: "sdlc-plugin", version: opts.pluginVersion ?? "1.4.0" };
+  await writeFile(
+    join(pluginDir, "plugin.json"),
+    JSON.stringify(plugin, null, 2) + "\n"
+  );
+
+  const changelog =
+    opts.changelog ??
+    `# Changelog\n\n## [1.4.0] - 2024-01-01\n\n### Changed\n- Initial\n`;
+  await writeFile(join(dir, "CHANGELOG.md"), changelog);
+}
+
+describe("release()", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = join(
+      import.meta.dir,
+      `__release_test_${Date.now()}_${Math.random().toString(36).slice(2)}`
+    );
+    await mkdir(tmpDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function runRelease(
+    type: "major" | "minor" | "patch"
+  ): Promise<{ exitCode: number }> {
+    const proc = Bun.spawn(
+      ["bun", "run", join(import.meta.dir, "release.ts"), type],
+      { cwd: tmpDir, stdout: "pipe", stderr: "pipe" }
+    );
+    const exitCode = await proc.exited;
+    return { exitCode };
+  }
+
+  test("patch: package.json version bumped", async () => {
+    await setupTempDir(tmpDir, { packageVersion: "2.0.0", pluginVersion: "2.0.0" });
+
+    const { exitCode } = await runRelease("patch");
+    expect(exitCode).toBe(0);
+
+    const pkg = JSON.parse(
+      await readFile(join(tmpDir, "package.json"), "utf-8")
+    );
+    expect(pkg.version).toBe("2.0.1");
+  });
+
+  test("patch: plugin.json version bumped", async () => {
+    await setupTempDir(tmpDir, { packageVersion: "2.0.0", pluginVersion: "2.0.0" });
+
+    await runRelease("patch");
+
+    const plugin = JSON.parse(
+      await readFile(join(tmpDir, ".claude-plugin/plugin.json"), "utf-8")
+    );
+    expect(plugin.version).toBe("2.0.1");
+  });
+
+  test("patch: CHANGELOG.md gets new entry inserted before existing entry", async () => {
+    await setupTempDir(tmpDir, {
+      packageVersion: "2.0.0",
+      pluginVersion: "2.0.0",
+      changelog: `# Changelog\n\n## [2.0.0] - 2024-01-01\n\n### Changed\n- Initial\n`,
+    });
+
+    await runRelease("patch");
+
+    const changelog = await readFile(join(tmpDir, "CHANGELOG.md"), "utf-8");
+    expect(changelog).toContain("## [2.0.1]");
+    expect(changelog).toContain("## [2.0.0]");
+    expect(changelog).toContain("- TODO: Add changes");
+    expect(changelog.indexOf("## [2.0.1]")).toBeLessThan(
+      changelog.indexOf("## [2.0.0]")
+    );
+  });
+
+  test("patch: CHANGELOG.md entry includes today's date", async () => {
+    await setupTempDir(tmpDir, {
+      packageVersion: "1.0.0",
+      pluginVersion: "1.0.0",
+      changelog: `# Changelog\n\n## [1.0.0] - 2024-01-01\n\n### Changed\n- Base\n`,
+    });
+
+    await runRelease("patch");
+
+    const today = formatDate();
+    const changelog = await readFile(join(tmpDir, "CHANGELOG.md"), "utf-8");
+    expect(changelog).toContain(`## [1.0.1] - ${today}`);
+  });
+
+  test("minor: bumps minor and resets patch in all three files", async () => {
+    await setupTempDir(tmpDir, {
+      packageVersion: "1.3.5",
+      pluginVersion: "1.3.5",
+      changelog: `# Changelog\n\n## [1.3.5] - 2024-01-01\n\n### Changed\n- Previous\n`,
+    });
+
+    const { exitCode } = await runRelease("minor");
+    expect(exitCode).toBe(0);
+
+    const pkg = JSON.parse(
+      await readFile(join(tmpDir, "package.json"), "utf-8")
+    );
+    expect(pkg.version).toBe("1.4.0");
+
+    const plugin = JSON.parse(
+      await readFile(join(tmpDir, ".claude-plugin/plugin.json"), "utf-8")
+    );
+    expect(plugin.version).toBe("1.4.0");
+
+    const changelog = await readFile(join(tmpDir, "CHANGELOG.md"), "utf-8");
+    expect(changelog).toContain("## [1.4.0]");
+    expect(changelog).toContain("## [1.3.5]");
+  });
+
+  test("major: bumps major and resets minor+patch in all three files", async () => {
+    await setupTempDir(tmpDir, {
+      packageVersion: "0.9.2",
+      pluginVersion: "0.9.2",
+      changelog: `# Changelog\n\n## [0.9.2] - 2024-01-01\n\n### Changed\n- Old\n`,
+    });
+
+    const { exitCode } = await runRelease("major");
+    expect(exitCode).toBe(0);
+
+    const pkg = JSON.parse(
+      await readFile(join(tmpDir, "package.json"), "utf-8")
+    );
+    expect(pkg.version).toBe("1.0.0");
+
+    const plugin = JSON.parse(
+      await readFile(join(tmpDir, ".claude-plugin/plugin.json"), "utf-8")
+    );
+    expect(plugin.version).toBe("1.0.0");
+
+    const changelog = await readFile(join(tmpDir, "CHANGELOG.md"), "utf-8");
+    expect(changelog).toContain("## [1.0.0]");
+    expect(changelog).toContain("## [0.9.2]");
+  });
+
+  test("changelog with no existing version header appends entry after document header", async () => {
+    await setupTempDir(tmpDir, {
+      packageVersion: "0.1.0",
+      pluginVersion: "0.1.0",
+      changelog: `# Changelog\n\nAll notable changes.\n`,
+    });
+
+    const { exitCode } = await runRelease("patch");
+    expect(exitCode).toBe(0);
+
+    const changelog = await readFile(join(tmpDir, "CHANGELOG.md"), "utf-8");
+    expect(changelog).toContain("## [0.1.1]");
+  });
+});

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -18,7 +18,7 @@ import { join } from "path";
 
 type BumpType = "major" | "minor" | "patch";
 
-function bumpVersion(current: string, type: BumpType): string {
+export function bumpVersion(current: string, type: BumpType): string {
   const [major, minor, patch] = current.split(".").map(Number);
   switch (type) {
     case "major":
@@ -30,7 +30,7 @@ function bumpVersion(current: string, type: BumpType): string {
   }
 }
 
-function formatDate(): string {
+export function formatDate(): string {
   return new Date().toISOString().split("T")[0];
 }
 
@@ -97,11 +97,13 @@ async function release(type: BumpType) {
   console.log("  4. git push && git push --tags");
 }
 
-// Parse CLI args
-const type = process.argv[2] as BumpType;
-if (!["major", "minor", "patch"].includes(type)) {
-  console.error("Usage: bun run scripts/release.ts <major|minor|patch>");
-  process.exit(1);
-}
+if (import.meta.main) {
+  // Parse CLI args
+  const type = process.argv[2] as BumpType;
+  if (!["major", "minor", "patch"].includes(type)) {
+    console.error("Usage: bun run scripts/release.ts <major|minor|patch>");
+    process.exit(1);
+  }
 
-release(type);
+  release(type);
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -40,7 +40,14 @@ async function release(type: BumpType) {
   // 1. Read current version from package.json
   const pkgPath = join(cwd, "package.json");
   const pkgContent = await readFile(pkgPath, "utf-8");
-  const pkg = JSON.parse(pkgContent);
+  let pkg: { version: string; [key: string]: unknown };
+  try {
+    pkg = JSON.parse(pkgContent);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse package.json as JSON: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
   const currentVersion = pkg.version;
   const newVersion = bumpVersion(currentVersion, type);
 

--- a/scripts/resolve-models.test.ts
+++ b/scripts/resolve-models.test.ts
@@ -28,17 +28,17 @@ describe("resolveCodexModels", () => {
 
   test("picks first visible mini model as fast variant", () => {
     const result = resolveCodexModels(codexCache);
-    expect(result.fast.id).toBe("gpt-5.4-mini");
+    expect(result.fast!.id).toBe("gpt-5.4-mini");
   });
 
   test("picks next visible non-mini model as previous", () => {
     const result = resolveCodexModels(codexCache);
-    expect(result.previous.id).toBe("gpt-5.3-codex");
+    expect(result.previous!.id).toBe("gpt-5.3-codex");
   });
 
   test("ignores hidden models", () => {
     const result = resolveCodexModels(codexCache);
-    const ids = [result.flagship.id, result.fast.id, result.previous.id];
+    const ids = [result.flagship.id, result.fast!.id, result.previous!.id];
     expect(ids).not.toContain("gpt-5.1-codex");
     expect(ids).not.toContain("gpt-5-codex-mini");
   });
@@ -88,12 +88,12 @@ describe("resolveGeminiModels", () => {
 
   test("picks highest-version flash model as fast (excluding lite)", () => {
     const result = resolveGeminiModels(geminiModels);
-    expect(result.fast.id).toBe("gemini-3-flash");
+    expect(result.fast!.id).toBe("gemini-3-flash");
   });
 
   test("filters out non-gemini models", () => {
     const result = resolveGeminiModels(geminiModels);
-    const allIds = [result.flagship.id, result.fast.id];
+    const allIds = [result.flagship.id, result.fast!.id];
     expect(allIds.every((id) => id.startsWith("gemini-"))).toBe(true);
   });
 

--- a/scripts/validate-plugin.test.ts
+++ b/scripts/validate-plugin.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from "bun:test";
+import { PluginManifestSchema } from "./validate-plugin";
+
+describe("PluginManifestSchema", () => {
+  const validManifest = {
+    name: "test-plugin",
+    version: "1.0.0",
+    description: "A test plugin",
+    author: { name: "Test Author" },
+  };
+
+  test("accepts valid minimal manifest", () => {
+    const result = PluginManifestSchema.safeParse(validManifest);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts manifest with all optional fields", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validManifest,
+      homepage: "https://example.com",
+      repository: "https://github.com/test/repo",
+      license: "MIT",
+      keywords: ["test", "plugin"],
+      commands: ["cmd1", "cmd2"],
+      agents: "agents/",
+      hooks: { "pre-commit": "echo test" },
+      mcpServers: { server1: { command: "node" } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing name", () => {
+    const { name, ...noName } = validManifest;
+    const result = PluginManifestSchema.safeParse(noName);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid version format", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validManifest,
+      version: "v1.0",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing author", () => {
+    const { author, ...noAuthor } = validManifest;
+    const result = PluginManifestSchema.safeParse(noAuthor);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid author email", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validManifest,
+      author: { name: "Test", email: "not-an-email" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts commands as string or array", () => {
+    const asString = PluginManifestSchema.safeParse({
+      ...validManifest,
+      commands: "commands/",
+    });
+    const asArray = PluginManifestSchema.safeParse({
+      ...validManifest,
+      commands: ["cmd1", "cmd2"],
+    });
+    expect(asString.success).toBe(true);
+    expect(asArray.success).toBe(true);
+  });
+
+  test("validates actual plugin.json", async () => {
+    const content = await Bun.file(".claude-plugin/plugin.json").text();
+    const json = JSON.parse(content);
+    const result = PluginManifestSchema.safeParse(json);
+    expect(result.success).toBe(true);
+  });
+});

--- a/scripts/validate-plugin.ts
+++ b/scripts/validate-plugin.ts
@@ -5,7 +5,7 @@ import { join } from 'path';
 import { existsSync } from 'fs';
 import { validateVersions } from './validate-versions';
 
-const PluginManifestSchema = z.object({
+export const PluginManifestSchema = z.object({
   name: z.string(),
   version: z.string().regex(/^\d+\.\d+\.\d+$/, 'Version must follow semver format'),
   description: z.string(),
@@ -168,4 +168,6 @@ async function main() {
   await checkModelRegistryStaleness();
 }
 
-main();
+if (import.meta.main) {
+  main();
+}

--- a/scripts/validate-versions.test.ts
+++ b/scripts/validate-versions.test.ts
@@ -1,0 +1,130 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, mkdir, writeFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { validateVersions } from "./validate-versions";
+
+async function writeJson(dir: string, rel: string, data: unknown) {
+  const full = join(dir, rel);
+  await mkdir(join(full, ".."), { recursive: true });
+  await writeFile(full, JSON.stringify(data, null, 2), "utf-8");
+}
+
+async function writeText(dir: string, rel: string, content: string) {
+  const full = join(dir, rel);
+  await mkdir(join(full, ".."), { recursive: true });
+  await writeFile(full, content, "utf-8");
+}
+
+const VERSION = "1.2.3";
+
+describe("validateVersions", () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), "validate-versions-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  // --- happy path ---
+
+  test("all versions match → success: true", async () => {
+    await writeJson(tmp, "package.json", { version: VERSION });
+    await writeJson(tmp, ".claude-plugin/plugin.json", { version: VERSION });
+    await writeText(tmp, "CHANGELOG.md", `## [${VERSION}] - 2024-01-01\n\n### Added\n- Initial release\n`);
+
+    const result = await validateVersions(tmp);
+
+    expect(result.success).toBe(true);
+    expect(result.mismatchDetails).toBeUndefined();
+    expect(result.versions.every((v) => v.version === VERSION || v.version === null)).toBe(true);
+  });
+
+  // --- mismatch cases ---
+
+  test("package.json version differs → success: false with mismatch details", async () => {
+    await writeJson(tmp, "package.json", { version: "9.9.9" });
+    await writeJson(tmp, ".claude-plugin/plugin.json", { version: VERSION });
+    await writeText(tmp, "CHANGELOG.md", `## [${VERSION}] - 2024-01-01\n`);
+
+    const result = await validateVersions(tmp);
+
+    expect(result.success).toBe(false);
+    expect(result.mismatchDetails).toBeDefined();
+    expect(result.mismatchDetails).toContain("Version mismatch detected");
+    expect(result.mismatchDetails).toContain("9.9.9");
+    expect(result.mismatchDetails).toContain(VERSION);
+
+    const pkgEntry = result.versions.find((v) => v.source === "package.json");
+    expect(pkgEntry?.version).toBe("9.9.9");
+  });
+
+  test("CHANGELOG.md version differs → success: false", async () => {
+    await writeJson(tmp, "package.json", { version: VERSION });
+    await writeJson(tmp, ".claude-plugin/plugin.json", { version: VERSION });
+    await writeText(tmp, "CHANGELOG.md", `## [0.0.1] - 2023-01-01\n`);
+
+    const result = await validateVersions(tmp);
+
+    expect(result.success).toBe(false);
+    expect(result.mismatchDetails).toContain("Version mismatch detected");
+
+    const changelogEntry = result.versions.find((v) => v.source === "CHANGELOG.md");
+    expect(changelogEntry?.version).toBe("0.0.1");
+  });
+
+  // --- missing / absent files ---
+
+  test("missing CHANGELOG.md → handles gracefully (version null)", async () => {
+    await writeJson(tmp, "package.json", { version: VERSION });
+    await writeJson(tmp, ".claude-plugin/plugin.json", { version: VERSION });
+    // no CHANGELOG.md written
+
+    const result = await validateVersions(tmp);
+
+    const changelogEntry = result.versions.find((v) => v.source === "CHANGELOG.md");
+    expect(changelogEntry?.version).toBeNull();
+
+    // Two files agree so it should still succeed
+    expect(result.success).toBe(true);
+  });
+
+  test("no version files found → success: false with 'No version information found'", async () => {
+    // tmp is empty — no package.json, no plugin.json, no CHANGELOG.md
+    const result = await validateVersions(tmp);
+
+    expect(result.success).toBe(false);
+    expect(result.mismatchDetails).toContain("No version information found");
+    expect(result.versions.every((v) => v.version === null)).toBe(true);
+  });
+
+  // --- CHANGELOG edge case ---
+
+  test("CHANGELOG has [Unreleased] section before versioned entry → still finds correct version", async () => {
+    const changelog = [
+      "# Changelog",
+      "",
+      "## [Unreleased]",
+      "### Added",
+      "- Something coming soon",
+      "",
+      `## [${VERSION}] - 2024-01-01`,
+      "### Added",
+      "- Initial release",
+      "",
+    ].join("\n");
+
+    await writeJson(tmp, "package.json", { version: VERSION });
+    await writeJson(tmp, ".claude-plugin/plugin.json", { version: VERSION });
+    await writeText(tmp, "CHANGELOG.md", changelog);
+
+    const result = await validateVersions(tmp);
+
+    expect(result.success).toBe(true);
+    const changelogEntry = result.versions.find((v) => v.source === "CHANGELOG.md");
+    expect(changelogEntry?.version).toBe(VERSION);
+  });
+});

--- a/skills/constitution-compliance-review/references/scoring-rubric.md
+++ b/skills/constitution-compliance-review/references/scoring-rubric.md
@@ -406,65 +406,67 @@ Format: Use gh pr create with markdown sections (## Summary, ## Test plan) for r
 **Level 2 (Rule-Heavy):**
 ```markdown
 Error Handling Rules:
-1. Always use try-catch blocks
-2. Log errors with console.error()
-3. Return error object with shape: {error: true, message: string}
-4. Never throw exceptions in async functions
-5. Always include stack traces in logs
+1. Use try-catch only at system boundaries (API handlers, queue consumers, cron entry points)
+2. Let errors propagate through business logic — do not catch and return null
+3. Log errors with console.error() at the boundary where you catch them
+4. Return error object with shape: {error: true, message: string} from boundary handlers
+5. Always include stack traces in error logs
 ```
 
 **Level 5 (Hybrid):**
 ```markdown
 Error Handling:
 
-Use try-catch blocks to handle errors gracefully.
+Catch errors at system boundaries (API route handlers, message queue consumers, cron jobs) — not inside business logic functions.
 
-When catching errors:
-- Log them for debugging (include stack trace)
-- Return a consistent error shape: {error: true, message: string}
+At boundaries:
+- Log the full error for debugging (include stack trace and request context)
+- Return a consistent error shape to the caller: {error: true, message: string}
 - Don't let exceptions crash the process
 
-Avoid throwing exceptions in async functions as they can cause unhandled promise rejections.
+Inside business logic, let errors propagate naturally. A function that catches an error and returns null hides the failure from every caller above it.
 ```
 
 **Level 7 (Mostly Reasoning):**
 ```markdown
 Error Handling:
 
-Goal: Fail gracefully with useful debugging information.
+Goal: Surface failures quickly with useful debugging information. Errors caught too early (inside business logic) hide bugs; errors caught too late (nowhere) crash processes.
 
-Handle errors so:
+The sweet spot is **system boundaries** — API handlers, queue consumers, cron entry points. These are where you translate internal errors into external responses:
 - Users get actionable messages (what went wrong, what to try)
 - Developers get debugging information (stack traces, context)
 - The process doesn't crash unexpectedly
 
-Pattern: Use try-catch for operations that might fail. Log the full error (stack trace) for debugging, but return a clean error object to callers with a user-friendly message.
+Inside business logic, let errors propagate. If `getUser()` fails, the caller should see the error — not a silent `null` that causes a confusing failure three layers up.
 
-Avoid throwing in async functions because unhandled promise rejections can crash the process. Return error objects instead.
+Exception: operations where partial failure is expected and recovery is defined (e.g., batch processing with per-item error handling).
 ```
 
 **Level 9 (Constitution-Aligned):**
 ```markdown
 Error Handling:
 
-Goal: Fail gracefully with information useful for both users and developers.
+Goal: Fail fast in business logic, fail gracefully at system edges.
 
-Good error handling:
-- Catches failures that might occur (file not found, network timeout, invalid input)
-- Logs full error details for debugging (stack trace, context, input values)
-- Returns actionable messages to users (what failed, why, what to try next)
-- Doesn't crash the process unexpectedly
+The core principle: errors should propagate through business logic untouched, then be caught and handled at system boundaries where you control the response format.
 
-Pattern: try-catch for fallible operations, log the error with context, return a clean error object.
+**System boundaries** (catch here):
+- API route handlers → log + return error response
+- Queue consumers → log + nack/retry
+- Cron entry points → log + alert
 
-Use your judgment:
-- For user-facing errors: focus on clarity ("File not found: config.json")
-- For developer-facing errors: include technical details ("Failed to parse JSON: unexpected token at line 5")
-- For retry-able failures: indicate that ("Network timeout; retry might succeed")
+**Business logic** (don't catch here):
+- Let errors propagate naturally — callers need to see failures
+- A function that catches and returns null hides bugs from every layer above it
+- If `getUser()` can fail, the caller must handle that possibility — don't mask it
 
-In async functions, prefer returning error objects over throwing because unhandled promise rejections can crash the process. Throw only when the caller is expected to catch immediately.
+Use your judgment on granularity:
+- A missing optional config file might warn and use defaults
+- A missing required file should throw clearly — don't `?? fallback` required data
+- Batch processing may catch per-item to continue processing remaining items
 
-Match error handling granularity to failure impact: a missing optional config file might warn and use defaults; a missing required file should error clearly.
+Match error handling to failure impact: the higher the impact, the faster it should surface.
 ```
 
 ---

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -116,6 +116,7 @@ After every RED-GREEN pair, verify:
 - [ ] **Public interface only**: Test uses the same API as production callers
 - [ ] **Survives refactor**: Would this test break if internals changed but behavior stayed the same?
 - [ ] **Minimal code**: Implementation is the simplest thing that passes — no speculative features
+- [ ] **No lookup tables**: Does the implementation compute results algorithmically, or did I hardcode return values that match the test inputs? If swapping test values would break the implementation, it's a lookup table — rewrite with real logic.
 - [ ] **No horizontal drift**: Did you write only ONE test before implementing? If you wrote multiple, STOP and revert to one.
 - [ ] **No type theater**: Does this test verify something the type system doesn't already guarantee? If the only way it could fail is a type error, delete it.
 

--- a/utils/search-mcp/__tests__/brave.test.ts
+++ b/utils/search-mcp/__tests__/brave.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { searchBrave } from "../providers/brave";
 import type { SearchInput, BraveOptions } from "../types";
 
+type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
 describe("searchBrave", () => {
   test("returns SearchResult from Brave response", async () => {
     const mockResponse = {
@@ -17,7 +19,7 @@ describe("searchBrave", () => {
       },
     };
 
-    const fakeFetch: typeof fetch = async () => {
+    const fakeFetch: FetchFn = async () => {
       return new Response(JSON.stringify(mockResponse), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -67,7 +69,7 @@ describe("searchBrave", () => {
       },
     };
 
-    const fakeFetch: typeof fetch = async () => {
+    const fakeFetch: FetchFn = async () => {
       return new Response(JSON.stringify(mockResponse), { status: 200 });
     };
 
@@ -109,7 +111,7 @@ describe("searchBrave", () => {
       },
     };
 
-    const fakeFetch: typeof fetch = async () => {
+    const fakeFetch: FetchFn = async () => {
       return new Response(JSON.stringify(mockResponse), { status: 200 });
     };
 
@@ -126,7 +128,7 @@ describe("searchBrave", () => {
   test("maps recency to freshness param in URL", async () => {
     const capturedUrls: string[] = [];
 
-    const fakeFetch: typeof fetch = async (input: RequestInfo | URL) => {
+    const fakeFetch: FetchFn = async (input: RequestInfo | URL) => {
       capturedUrls.push(input.toString());
       return new Response(JSON.stringify({ web: { results: [] } }), { status: 200 });
     };
@@ -157,7 +159,7 @@ describe("searchBrave", () => {
   test("clamps num_results to max 20", async () => {
     const capturedUrls: string[] = [];
 
-    const fakeFetch: typeof fetch = async (input: RequestInfo | URL) => {
+    const fakeFetch: FetchFn = async (input: RequestInfo | URL) => {
       capturedUrls.push(input.toString());
       return new Response(JSON.stringify({ web: { results: [] } }), { status: 200 });
     };
@@ -178,7 +180,7 @@ describe("searchBrave", () => {
       web: {},
     };
 
-    const fakeFetch: typeof fetch = async () => {
+    const fakeFetch: FetchFn = async () => {
       return new Response(JSON.stringify(mockResponse), { status: 200 });
     };
 
@@ -213,7 +215,7 @@ describe("searchBrave", () => {
       },
     };
 
-    const fakeFetch: typeof fetch = async () => {
+    const fakeFetch: FetchFn = async () => {
       return new Response(JSON.stringify(mockResponse), { status: 200 });
     };
 
@@ -228,7 +230,7 @@ describe("searchBrave", () => {
   });
 
   test("measures latencyMs", async () => {
-    const fakeFetch: typeof fetch = async () => {
+    const fakeFetch: FetchFn = async () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
       return new Response(JSON.stringify({ web: { results: [] } }), { status: 200 });
     };
@@ -244,7 +246,7 @@ describe("searchBrave", () => {
   });
 
   test("throws on non-OK response with status", async () => {
-    const fakeFetch: typeof fetch = async () => {
+    const fakeFetch: FetchFn = async () => {
       return new Response(JSON.stringify({ error: "Invalid API key" }), { status: 401 });
     };
 
@@ -261,7 +263,7 @@ describe("searchBrave", () => {
   test(
     "throws on timeout",
     async () => {
-      const fakeFetch: typeof fetch = async (_url, options?: RequestInit) => {
+      const fakeFetch: FetchFn = async (_url, options?: RequestInit) => {
         return new Promise((resolve, reject) => {
           const signal = options?.signal;
           if (signal) {

--- a/utils/search-mcp/index.ts
+++ b/utils/search-mcp/index.ts
@@ -9,6 +9,7 @@ import type {
   PerplexityOptions,
   ExaOptions,
   BraveOptions,
+  ToolOutput,
 } from "./types";
 import { validateProviderParams } from "./types";
 import { formatResponse } from "./format";
@@ -72,6 +73,127 @@ export function buildToolDescription(
   return `Search via Exa, Brave, or Perplexity APIs. Provides deeper, more configurable results than built-in WebSearch. Available: ${providerList}. Omit 'provider' to use ${defaultProvider}.`;
 }
 
+// --- Request handler (extracted for testability) ---
+
+interface SearchDeps {
+  available: SearchProvider[];
+  envKeys: {
+    OPENROUTER_API_KEY: string;
+    OPENROUTER_MODEL: string;
+    EXA_API_KEY: string;
+    BRAVE_API_KEY: string;
+  };
+  exaClient: ExaClient | undefined;
+  defaultProvider: SearchProvider;
+}
+
+export async function handleSearchRequest(
+  args: Record<string, unknown>,
+  deps: SearchDeps
+): Promise<ToolOutput> {
+  const { available, envKeys, exaClient, defaultProvider } = deps;
+  const provider = ((args.provider ?? defaultProvider) as SearchProvider);
+
+  // Check provider availability
+  if (!available.includes(provider)) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Provider '${provider}' is not available. Available: ${available.join(", ")}. Set ${ENV_KEY_MAP[provider]} to enable.`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  // Validate provider-specific params (FR-7)
+  const paramErrors = validateProviderParams(provider, args);
+  if (paramErrors.length > 0) {
+    return {
+      content: [{ type: "text" as const, text: paramErrors.join("\n") }],
+      isError: true,
+    };
+  }
+
+  const input: SearchInput = {
+    query: args.query as string,
+    provider,
+    recency: args.recency as SearchInput["recency"],
+    num_results: args.num_results as number | undefined,
+  };
+
+  try {
+    let result;
+
+    switch (provider) {
+      case "perplexity": {
+        const perplexityOpts: PerplexityOptions = {
+          model: args.model as string | undefined,
+          temperature: args.temperature as number | undefined,
+          top_p: args.top_p as number | undefined,
+          top_k: args.top_k as number | undefined,
+          max_tokens: args.max_tokens as number | undefined,
+          frequency_penalty: args.frequency_penalty as number | undefined,
+          presence_penalty: args.presence_penalty as number | undefined,
+        };
+        result = await searchPerplexity(input, perplexityOpts, {
+          apiKey: envKeys.OPENROUTER_API_KEY,
+          defaultModel: envKeys.OPENROUTER_MODEL,
+        });
+        break;
+      }
+
+      case "exa": {
+        if (!exaClient) {
+          return {
+            content: [{ type: "text" as const, text: "Exa client not initialized. Set EXA_API_KEY to enable." }],
+            isError: true,
+          };
+        }
+        const exaOpts: ExaOptions = {
+          search_type: args.search_type as ExaOptions["search_type"],
+          include_domains: args.include_domains as string[] | undefined,
+          exclude_domains: args.exclude_domains as string[] | undefined,
+          category: args.category as string | undefined,
+          include_text: args.include_text as boolean | undefined,
+        };
+        result = await searchExa(input, exaOpts, {
+          client: exaClient,
+        });
+        break;
+      }
+
+      case "brave": {
+        const braveOpts: BraveOptions = {
+          result_filter: args.result_filter as BraveOptions["result_filter"],
+        };
+        result = await searchBrave(input, braveOpts, {
+          apiKey: envKeys.BRAVE_API_KEY,
+        });
+        break;
+      }
+
+      default: {
+        const _exhaustive: never = provider;
+        throw new Error(`Unknown provider: ${_exhaustive}`);
+      }
+    }
+
+    return formatResponse(result);
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `${provider} error: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
 // --- Server startup (only runs when executed directly) ---
 
 function startServer() {
@@ -90,6 +212,8 @@ function startServer() {
   if (available.includes("exa")) {
     exaClient = new Exa(envKeys.EXA_API_KEY) as unknown as ExaClient;
   }
+
+  const searchDeps: SearchDeps = { available, envKeys, exaClient, defaultProvider };
 
   const server = new McpServer({ name: "fast_deep_search", version: "1.0.0" });
 
@@ -149,103 +273,7 @@ function startServer() {
           .describe("Result type filter (Brave only). Only 'web' supported."),
       },
     },
-    async (args) => {
-      const provider = (args.provider ?? defaultProvider) as SearchProvider;
-
-      // Check provider availability
-      if (!available.includes(provider)) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Provider '${provider}' is not available. Available: ${available.join(", ")}. Set ${ENV_KEY_MAP[provider]} to enable.`,
-            },
-          ],
-          isError: true,
-        };
-      }
-
-      // Validate provider-specific params (FR-7)
-      const paramErrors = validateProviderParams(provider, args);
-      if (paramErrors.length > 0) {
-        return {
-          content: [{ type: "text" as const, text: paramErrors.join("\n") }],
-          isError: true,
-        };
-      }
-
-      const input: SearchInput = {
-        query: args.query,
-        provider,
-        recency: args.recency as SearchInput["recency"],
-        num_results: args.num_results,
-      };
-
-      try {
-        let result;
-
-        switch (provider) {
-          case "perplexity": {
-            const perplexityOpts: PerplexityOptions = {
-              model: args.model,
-              temperature: args.temperature,
-              top_p: args.top_p,
-              top_k: args.top_k,
-              max_tokens: args.max_tokens,
-              frequency_penalty: args.frequency_penalty,
-              presence_penalty: args.presence_penalty,
-            };
-            result = await searchPerplexity(input, perplexityOpts, {
-              apiKey: envKeys.OPENROUTER_API_KEY,
-              defaultModel: envKeys.OPENROUTER_MODEL,
-            });
-            break;
-          }
-
-          case "exa": {
-            if (!exaClient) {
-              return {
-                content: [{ type: "text" as const, text: "Exa client not initialized. Set EXA_API_KEY to enable." }],
-                isError: true,
-              };
-            }
-            const exaOpts: ExaOptions = {
-              search_type: args.search_type as ExaOptions["search_type"],
-              include_domains: args.include_domains,
-              exclude_domains: args.exclude_domains,
-              category: args.category,
-              include_text: args.include_text,
-            };
-            result = await searchExa(input, exaOpts, {
-              client: exaClient,
-            });
-            break;
-          }
-
-          case "brave": {
-            const braveOpts: BraveOptions = {
-              result_filter: args.result_filter as BraveOptions["result_filter"],
-            };
-            result = await searchBrave(input, braveOpts, {
-              apiKey: envKeys.BRAVE_API_KEY,
-            });
-            break;
-          }
-        }
-
-        return formatResponse(result);
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: `${provider} error: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-          isError: true,
-        };
-      }
-    }
+    (args) => handleSearchRequest(args as Record<string, unknown>, searchDeps)
   );
 
   async function main() {

--- a/utils/search-mcp/providers/brave.ts
+++ b/utils/search-mcp/providers/brave.ts
@@ -23,11 +23,11 @@ const FRESHNESS_MAP: Record<Recency, string> = {
 
 export async function searchBrave(
   input: SearchInput,
-  _options: BraveOptions,
-  deps: { apiKey: string; baseUrl?: string; fetchFn?: FetchFn }
+  options: BraveOptions,
+  deps: { apiKey: string; baseUrl?: string; fetchFn?: FetchFn; timeoutMs?: number }
 ): Promise<SearchResult> {
   const startTime = performance.now();
-  const { apiKey, baseUrl = "https://api.search.brave.com/res/v1/web/search", fetchFn = fetch } = deps;
+  const { apiKey, baseUrl = "https://api.search.brave.com/res/v1/web/search", fetchFn = fetch, timeoutMs = 30_000 } = deps;
 
   // Build query params
   const params = new URLSearchParams();
@@ -42,11 +42,15 @@ export async function searchBrave(
     params.set("freshness", FRESHNESS_MAP[input.recency]);
   }
 
+  if (options.result_filter) {
+    params.set("result_filter", options.result_filter);
+  }
+
   const url = `${baseUrl}?${params.toString()}`;
 
-  // Create AbortController with 30s timeout
+  // Create AbortController with configurable timeout
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 30000);
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
     const response = await fetchFn(url, {
@@ -99,7 +103,7 @@ export async function searchBrave(
     clearTimeout(timeoutId);
 
     if (error instanceof Error && error.name === "AbortError") {
-      throw new Error("brave error (timeout): Request timed out after 30s");
+      throw new Error(`brave error (timeout): Request timed out after ${timeoutMs / 1000}s`);
     }
 
     throw error;

--- a/utils/x-search/lib/api.ts
+++ b/utils/x-search/lib/api.ts
@@ -42,6 +42,20 @@ export interface Tweet {
   tweet_url: string;
 }
 
+export interface TwitterUser {
+  id: string;
+  username: string;
+  name: string;
+  description?: string;
+  created_at?: string;
+  public_metrics?: {
+    followers_count: number;
+    following_count: number;
+    tweet_count: number;
+    listed_count?: number;
+  };
+}
+
 interface RawResponse {
   data?: any[];
   includes?: { users?: any[] };
@@ -228,8 +242,8 @@ export async function thread(
         }
       }
     }
-  } catch (e: any) {
-    console.error(`(root tweet ${conversationId}: ${e.message})`);
+  } catch (e: unknown) {
+    console.error(`(root tweet ${conversationId}: ${e instanceof Error ? e.message : String(e)})`);
   }
 
   return tweets;
@@ -241,7 +255,7 @@ export async function thread(
 export async function profile(
   username: string,
   opts: { count?: number; includeReplies?: boolean } = {}
-): Promise<{ user: any; tweets: Tweet[] }> {
+): Promise<{ user: TwitterUser; tweets: Tweet[] }> {
   const userUrl = `${BASE}/users/by/username/${username}?user.fields=public_metrics,description,created_at`;
   const userData = await apiGet(userUrl);
 
@@ -249,7 +263,7 @@ export async function profile(
     throw new Error(`User @${username} not found`);
   }
 
-  const user = (userData as any).data;
+  const user = (userData as unknown as { data: TwitterUser }).data;
   await sleep(RATE_DELAY_MS);
 
   const replyFilter = opts.includeReplies ? "" : " -is:reply";

--- a/utils/x-search/lib/cache.test.ts
+++ b/utils/x-search/lib/cache.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test, beforeEach, mock } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// In-memory fs mock
+// We redirect all fs operations to a Map<path, string> store so tests never
+// touch the real filesystem and run instantly regardless of cwd.
+// ---------------------------------------------------------------------------
+
+const store = new Map<string, string>();
+const mtimes = new Map<string, number>();
+let dirEnsured = false;
+
+mock.module("fs", () => ({
+  existsSync: (p: string) => {
+    // treat the cache dir as "existing" after ensureDir runs
+    if (!p.endsWith(".json")) return dirEnsured;
+    return store.has(p);
+  },
+  mkdirSync: (_p: string, _opts?: unknown) => {
+    dirEnsured = true;
+  },
+  readFileSync: (p: string, _enc: string) => {
+    const v = store.get(p);
+    if (v === undefined) throw new Error(`ENOENT: ${p}`);
+    return v;
+  },
+  writeFileSync: (p: string, data: string) => {
+    store.set(p, data);
+    mtimes.set(p, Date.now());
+  },
+  readdirSync: (_p: string) => {
+    return [...store.keys()].map((k) => k.split("/").at(-1) as string);
+  },
+  statSync: (p: string) => {
+    const mt = mtimes.get(p);
+    if (mt === undefined) throw new Error(`ENOENT: ${p}`);
+    return { mtimeMs: mt };
+  },
+  unlinkSync: (p: string) => {
+    store.delete(p);
+    mtimes.delete(p);
+  },
+}));
+
+// Import AFTER the mock is registered so the module picks up the fake fs.
+const { get, set, prune, clear } = await import("./cache");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTweet(id: string) {
+  return {
+    id,
+    text: `tweet ${id}`,
+    author_id: "u1",
+    username: "testuser",
+    name: "Test User",
+    created_at: new Date().toISOString(),
+    conversation_id: id,
+    metrics: { likes: 0, retweets: 0, replies: 0, quotes: 0, impressions: 0, bookmarks: 0 },
+    urls: [],
+    mentions: [],
+    hashtags: [],
+    tweet_url: `https://x.com/testuser/status/${id}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reset store between tests for isolation
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  store.clear();
+  mtimes.clear();
+  dirEnsured = false;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("cache", () => {
+  describe("get()", () => {
+    test("returns null for a missing key", () => {
+      const result = get("nonexistent query");
+      expect(result).toBeNull();
+    });
+
+    test("returns null for a missing key with params", () => {
+      const result = get("some query", "lang:en");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("set() then get() round-trip", () => {
+    test("retrieves tweets that were stored", () => {
+      const tweets = [makeTweet("1"), makeTweet("2")];
+      set("hello world", "", tweets);
+
+      const result = get("hello world");
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(2);
+      expect(result![0].id).toBe("1");
+      expect(result![1].id).toBe("2");
+    });
+
+    test("different queries are stored independently", () => {
+      const t1 = [makeTweet("a")];
+      const t2 = [makeTweet("b"), makeTweet("c")];
+      set("query one", "", t1);
+      set("query two", "", t2);
+
+      expect(get("query one")).toEqual(t1);
+      expect(get("query two")).toEqual(t2);
+    });
+
+    test("params distinguish separate cache entries", () => {
+      const t1 = [makeTweet("p1")];
+      const t2 = [makeTweet("p2")];
+      set("bun", "lang:en", t1);
+      set("bun", "lang:ja", t2);
+
+      expect(get("bun", "lang:en")).toEqual(t1);
+      expect(get("bun", "lang:ja")).toEqual(t2);
+    });
+
+    test("stores an empty tweet array", () => {
+      set("empty", "", []);
+      const result = get("empty");
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("TTL expiry", () => {
+    test("returns tweets within TTL", () => {
+      const tweets = [makeTweet("fresh")];
+      set("ttl query", "", tweets);
+      // 60 second TTL — should still be valid
+      const result = get("ttl query", "", 60_000);
+      expect(result).toEqual(tweets);
+    });
+
+    test("returns null and deletes file when entry is expired", () => {
+      const tweets = [makeTweet("stale")];
+      set("expired query", "", tweets);
+
+      // Back-date the timestamp inside the stored JSON
+      const keys = [...store.keys()];
+      for (const k of keys) {
+        const entry = JSON.parse(store.get(k)!);
+        entry.timestamp = Date.now() - 5_000; // 5 seconds ago
+        store.set(k, JSON.stringify(entry));
+      }
+
+      // TTL of 1 ms — entry is expired
+      const result = get("expired query", "", 1);
+      expect(result).toBeNull();
+
+      // File must have been deleted
+      expect([...store.keys()].length).toBe(0);
+    });
+
+    test("1 ms TTL: immediate expiry", () => {
+      set("flash", "", [makeTweet("x")]);
+
+      const keys = [...store.keys()];
+      for (const k of keys) {
+        const entry = JSON.parse(store.get(k)!);
+        entry.timestamp = Date.now() - 100;
+        store.set(k, JSON.stringify(entry));
+      }
+
+      expect(get("flash", "", 1)).toBeNull();
+    });
+  });
+
+  describe("prune()", () => {
+    test("removes expired entries and returns count", () => {
+      // Two stale entries + one fresh
+      set("stale1", "", [makeTweet("s1")]);
+      set("stale2", "", [makeTweet("s2")]);
+      set("fresh", "", [makeTweet("f1")]);
+
+      // Age the first two entries via mtime
+      const allKeys = [...store.keys()];
+      const staleKeys = allKeys.slice(0, 2);
+      for (const k of staleKeys) {
+        mtimes.set(k, Date.now() - 10_000); // 10 s old
+      }
+
+      const removed = prune(5_000); // TTL = 5 s → two entries expired
+      expect(removed).toBe(2);
+
+      // Fresh entry survives
+      expect(store.size).toBe(1);
+    });
+
+    test("returns 0 when no entries are expired", () => {
+      set("a", "", [makeTweet("a")]);
+      set("b", "", [makeTweet("b")]);
+
+      const removed = prune(60_000); // generous TTL
+      expect(removed).toBe(0);
+      expect(store.size).toBe(2);
+    });
+
+    test("returns 0 on an empty cache", () => {
+      expect(prune()).toBe(0);
+    });
+  });
+
+  describe("clear()", () => {
+    test("removes all entries and returns count", () => {
+      set("x", "", [makeTweet("1")]);
+      set("y", "", [makeTweet("2")]);
+      set("z", "", [makeTweet("3")]);
+
+      const removed = clear();
+      expect(removed).toBe(3);
+      expect(store.size).toBe(0);
+    });
+
+    test("returns 0 when cache is already empty", () => {
+      expect(clear()).toBe(0);
+    });
+
+    test("get() returns null after clear()", () => {
+      const tweets = [makeTweet("gone")];
+      set("will be cleared", "", tweets);
+      clear();
+      expect(get("will be cleared")).toBeNull();
+    });
+  });
+});

--- a/utils/x-search/lib/format.test.ts
+++ b/utils/x-search/lib/format.test.ts
@@ -328,8 +328,8 @@ describe("formatProfileTelegram", () => {
   test("handles missing public_metrics gracefully", () => {
     const user = makeUser({ public_metrics: undefined });
     const out = formatProfileTelegram(user, []);
-    expect(out).toContain("0 followers");
-    expect(out).toContain("0 tweets");
+    expect(out).toContain("metrics unavailable");
+    expect(out).not.toContain("followers");
   });
 
   test("includes recent tweets in output", () => {

--- a/utils/x-search/lib/format.test.ts
+++ b/utils/x-search/lib/format.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import type { Tweet, TwitterUser } from "./api";
+import {
+  formatTweetTelegram,
+  formatResultsTelegram,
+  formatTweetMarkdown,
+  formatResearchMarkdown,
+  formatProfileTelegram,
+} from "./format";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeTweet(overrides: Partial<Tweet> = {}): Tweet {
+  return {
+    id: "123",
+    text: "Hello world",
+    author_id: "u1",
+    username: "testuser",
+    name: "Test User",
+    created_at: new Date(Date.now() - 30 * 60_000).toISOString(), // 30m ago
+    conversation_id: "123",
+    metrics: {
+      likes: 42,
+      retweets: 5,
+      replies: 2,
+      quotes: 1,
+      impressions: 1200,
+      bookmarks: 3,
+    },
+    urls: [],
+    mentions: [],
+    hashtags: [],
+    tweet_url: "https://x.com/testuser/status/123",
+    ...overrides,
+  };
+}
+
+function makeUser(overrides: Partial<TwitterUser> = {}): TwitterUser {
+  return {
+    id: "u1",
+    username: "testuser",
+    name: "Test User",
+    description: "Engineer building things",
+    public_metrics: {
+      followers_count: 5400,
+      following_count: 300,
+      tweet_count: 1200,
+    },
+    ...overrides,
+  };
+}
+
+// ── compactNumber (tested indirectly via formatTweetTelegram) ──────────────
+
+describe("compactNumber formatting (via formatTweetTelegram)", () => {
+  test("plain number stays as-is", () => {
+    const t = makeTweet({ metrics: { ...makeTweet().metrics, likes: 42, impressions: 999 } });
+    const out = formatTweetTelegram(t);
+    expect(out).toContain("42L");
+    expect(out).toContain("999I");
+  });
+
+  test("thousands are formatted with K", () => {
+    const t = makeTweet({ metrics: { ...makeTweet().metrics, likes: 1500, impressions: 10000 } });
+    const out = formatTweetTelegram(t);
+    expect(out).toContain("1.5K");
+    expect(out).toContain("10.0K");
+  });
+
+  test("millions are formatted with M", () => {
+    const t = makeTweet({ metrics: { ...makeTweet().metrics, likes: 2_500_000, impressions: 1_000_000 } });
+    const out = formatTweetTelegram(t);
+    expect(out).toContain("2.5M");
+    expect(out).toContain("1.0M");
+  });
+
+  test("zero remains as 0", () => {
+    const t = makeTweet({ metrics: { ...makeTweet().metrics, likes: 0, impressions: 0 } });
+    const out = formatTweetTelegram(t);
+    expect(out).toContain("0L");
+    expect(out).toContain("0I");
+  });
+});
+
+// ── formatTweetTelegram ────────────────────────────────────────────────────
+
+describe("formatTweetTelegram", () => {
+  test("includes username, engagement, and tweet URL", () => {
+    const t = makeTweet();
+    const out = formatTweetTelegram(t);
+    expect(out).toContain("@testuser");
+    expect(out).toContain("42L");
+    expect(out).toContain("1.2K");
+    expect(out).toContain("https://x.com/testuser/status/123");
+  });
+
+  test("prepends index when provided", () => {
+    const out0 = formatTweetTelegram(makeTweet(), 0);
+    const out2 = formatTweetTelegram(makeTweet(), 2);
+    expect(out0).toMatch(/^1\. /);
+    expect(out2).toMatch(/^3\. /);
+  });
+
+  test("no index prefix when index is omitted", () => {
+    const out = formatTweetTelegram(makeTweet());
+    expect(out).not.toMatch(/^\d+\. /);
+  });
+
+  test("strips t.co short links from text", () => {
+    const t = makeTweet({ text: "Check this out https://t.co/abcXYZ cool" });
+    const out = formatTweetTelegram(t);
+    expect(out).not.toContain("https://t.co/");
+    expect(out).toContain("Check this out");
+    expect(out).toContain("cool");
+  });
+
+  test("appends first url when urls present", () => {
+    const t = makeTweet({ urls: ["https://example.com/article", "https://other.com"] });
+    const out = formatTweetTelegram(t);
+    expect(out).toContain("https://example.com/article");
+    expect(out).not.toContain("https://other.com");
+  });
+
+  test("no extra url line when urls is empty", () => {
+    const t = makeTweet({ urls: [] });
+    const out = formatTweetTelegram(t);
+    // Only tweet_url should appear, not a separate url line
+    const lines = out.split("\n");
+    // tweet_url is the last line
+    expect(lines[lines.length - 1]).toBe("https://x.com/testuser/status/123");
+    expect(lines.length).toBe(3); // "prefix@user (eng · time)", text, tweet_url
+  });
+
+  test("truncates text longer than 200 chars", () => {
+    const longText = "a".repeat(210);
+    const t = makeTweet({ text: longText });
+    const out = formatTweetTelegram(t);
+    expect(out).toContain("...");
+    // The displayed text line should be 200 chars (197 + "...")
+    const textLine = out.split("\n")[1];
+    expect(textLine.length).toBeLessThanOrEqual(200);
+  });
+
+  test("text at exactly 200 chars is not truncated", () => {
+    const text = "b".repeat(200);
+    const t = makeTweet({ text });
+    const out = formatTweetTelegram(t);
+    expect(out).not.toContain("...");
+  });
+
+  test("includes time ago in output", () => {
+    // tweet is 30m ago → should show "30m"
+    const out = formatTweetTelegram(makeTweet());
+    expect(out).toMatch(/\d+m/);
+  });
+});
+
+// ── formatResultsTelegram ──────────────────────────────────────────────────
+
+describe("formatResultsTelegram", () => {
+  test("formats multiple tweets separated by double newlines", () => {
+    const tweets = [makeTweet({ id: "1" }), makeTweet({ id: "2" })];
+    const out = formatResultsTelegram(tweets);
+    expect(out).toContain("\n\n");
+  });
+
+  test("includes query header when query provided", () => {
+    const out = formatResultsTelegram([makeTweet()], { query: "typescript" });
+    expect(out).toContain('"typescript"');
+    expect(out).toContain("1 results");
+  });
+
+  test("no query header when query omitted", () => {
+    const out = formatResultsTelegram([makeTweet()]);
+    expect(out).not.toMatch(/^"/);
+  });
+
+  test("respects limit option", () => {
+    const tweets = Array.from({ length: 20 }, (_, i) => makeTweet({ id: String(i) }));
+    const out = formatResultsTelegram(tweets, { limit: 3 });
+    expect(out).toContain("+17 more");
+  });
+
+  test("default limit is 15", () => {
+    const tweets = Array.from({ length: 20 }, (_, i) => makeTweet({ id: String(i) }));
+    const out = formatResultsTelegram(tweets);
+    expect(out).toContain("+5 more");
+  });
+
+  test("no 'more' line when count is within limit", () => {
+    const tweets = [makeTweet()];
+    const out = formatResultsTelegram(tweets);
+    expect(out).not.toContain("more");
+  });
+
+  test("empty tweet array returns empty string (no query)", () => {
+    const out = formatResultsTelegram([]);
+    expect(out).toBe("");
+  });
+});
+
+// ── formatTweetMarkdown ────────────────────────────────────────────────────
+
+describe("formatTweetMarkdown", () => {
+  test("formats username in bold with tweet link", () => {
+    const out = formatTweetMarkdown(makeTweet());
+    expect(out).toContain("**@testuser**");
+    expect(out).toContain("[Tweet](https://x.com/testuser/status/123)");
+  });
+
+  test("includes raw like and impression counts", () => {
+    const out = formatTweetMarkdown(makeTweet());
+    expect(out).toContain("42L");
+    expect(out).toContain("1200I");
+  });
+
+  test("strips t.co links from text", () => {
+    const t = makeTweet({ text: "See https://t.co/abcXYZ here" });
+    const out = formatTweetMarkdown(t);
+    expect(out).not.toContain("https://t.co/");
+    expect(out).toContain("See");
+    expect(out).toContain("here");
+  });
+
+  test("includes links section with hostnames when urls present", () => {
+    const t = makeTweet({ urls: ["https://github.com/user/repo"] });
+    const out = formatTweetMarkdown(t);
+    expect(out).toContain("Links:");
+    expect(out).toContain("[github.com](https://github.com/user/repo)");
+  });
+
+  test("no links section when urls empty", () => {
+    const out = formatTweetMarkdown(makeTweet({ urls: [] }));
+    expect(out).not.toContain("Links:");
+  });
+
+  test("multiline text is blockquoted with continuation markers", () => {
+    const t = makeTweet({ text: "line one\nline two" });
+    const out = formatTweetMarkdown(t);
+    expect(out).toContain("line one\n  > line two");
+  });
+});
+
+// ── formatResearchMarkdown ─────────────────────────────────────────────────
+
+describe("formatResearchMarkdown", () => {
+  const today = new Date().toISOString().split("T")[0];
+
+  test("includes query and date in header", () => {
+    const out = formatResearchMarkdown("test query", []);
+    expect(out).toContain("# X Research: test query");
+    expect(out).toContain(`**Date:** ${today}`);
+  });
+
+  test("lists tweet count", () => {
+    const out = formatResearchMarkdown("q", [makeTweet(), makeTweet({ id: "2" })]);
+    expect(out).toContain("**Tweets found:** 2");
+  });
+
+  test("renders Top Results section when no themes given", () => {
+    const out = formatResearchMarkdown("q", [makeTweet()]);
+    expect(out).toContain("## Top Results (by engagement)");
+  });
+
+  test("renders themed sections when themes provided", () => {
+    const tweet = makeTweet({ id: "abc" });
+    const out = formatResearchMarkdown("q", [tweet], {
+      themes: [{ title: "Performance", tweetIds: ["abc"] }],
+    });
+    expect(out).toContain("## Performance");
+    expect(out).toContain("@testuser");
+    expect(out).not.toContain("## Top Results");
+  });
+
+  test("includes api call count when provided", () => {
+    const out = formatResearchMarkdown("q", [], { apiCalls: 7 });
+    expect(out).toContain("**API calls:** 7");
+  });
+
+  test("omits api calls line when not provided", () => {
+    const out = formatResearchMarkdown("q", []);
+    expect(out).not.toContain("API calls");
+  });
+
+  test("includes search queries when provided", () => {
+    const out = formatResearchMarkdown("q", [], { queries: ["alpha", "beta"] });
+    expect(out).toContain("`alpha`");
+    expect(out).toContain("`beta`");
+  });
+
+  test("includes estimated cost", () => {
+    const tweets = Array.from({ length: 10 }, (_, i) => makeTweet({ id: String(i) }));
+    const out = formatResearchMarkdown("q", tweets);
+    expect(out).toContain("Est. cost:");
+    expect(out).toContain("$0.05");
+  });
+});
+
+// ── formatProfileTelegram ──────────────────────────────────────────────────
+
+describe("formatProfileTelegram", () => {
+  test("includes username, name, follower and tweet counts", () => {
+    const out = formatProfileTelegram(makeUser(), []);
+    expect(out).toContain("@testuser — Test User");
+    expect(out).toContain("5.4K followers");
+    expect(out).toContain("1.2K tweets");
+  });
+
+  test("includes description when present", () => {
+    const out = formatProfileTelegram(makeUser(), []);
+    expect(out).toContain("Engineer building things");
+  });
+
+  test("description is omitted when not set", () => {
+    const user = makeUser({ description: undefined });
+    const out = formatProfileTelegram(user, []);
+    expect(out).not.toContain("Engineer");
+  });
+
+  test("truncates description longer than 150 chars", () => {
+    const longDesc = "x".repeat(200);
+    const user = makeUser({ description: longDesc });
+    const out = formatProfileTelegram(user, []);
+    expect(out).toContain("x".repeat(150));
+    expect(out).not.toContain("x".repeat(151));
+  });
+
+  test("handles missing public_metrics gracefully", () => {
+    const user = makeUser({ public_metrics: undefined });
+    const out = formatProfileTelegram(user, []);
+    expect(out).toContain("0 followers");
+    expect(out).toContain("0 tweets");
+  });
+
+  test("includes recent tweets in output", () => {
+    const tweets = [
+      makeTweet({ id: "1", text: "First tweet" }),
+      makeTweet({ id: "2", text: "Second tweet" }),
+    ];
+    const out = formatProfileTelegram(makeUser(), tweets);
+    expect(out).toContain("Recent:");
+    expect(out).toContain("First tweet");
+    expect(out).toContain("Second tweet");
+  });
+
+  test("shows at most 10 tweets", () => {
+    const tweets = Array.from({ length: 15 }, (_, i) =>
+      makeTweet({ id: String(i), text: `Tweet ${i}` })
+    );
+    const out = formatProfileTelegram(makeUser(), tweets);
+    // Tweet 10 (index 10, "Tweet 10") should NOT appear
+    expect(out).not.toContain("Tweet 10");
+    // Tweet 9 (index 9, "Tweet 9") should appear
+    expect(out).toContain("Tweet 9");
+  });
+
+  test("works with empty tweet list", () => {
+    const out = formatProfileTelegram(makeUser(), []);
+    expect(out).toContain("Recent:");
+  });
+});

--- a/utils/x-search/lib/format.ts
+++ b/utils/x-search/lib/format.ts
@@ -140,9 +140,11 @@ export function formatResearchMarkdown(
  * Format a user profile for Telegram.
  */
 export function formatProfileTelegram(user: TwitterUser, tweets: Tweet[]): string {
-  const m = user.public_metrics ?? { followers_count: 0, following_count: 0, tweet_count: 0 };
+  const m = user.public_metrics;
   let out = `@${user.username} — ${user.name}\n`;
-  out += `${compactNumber(m.followers_count || 0)} followers · ${compactNumber(m.tweet_count || 0)} tweets\n`;
+  out += m
+    ? `${compactNumber(m.followers_count)} followers · ${compactNumber(m.tweet_count)} tweets\n`
+    : `metrics unavailable\n`;
   if (user.description) {
     out += `${user.description.slice(0, 150)}\n`;
   }

--- a/utils/x-search/lib/format.ts
+++ b/utils/x-search/lib/format.ts
@@ -4,7 +4,7 @@
  * Adapted from rohunvora/x-research-skill (public repo, no explicit license).
  */
 
-import type { Tweet } from "./api";
+import type { Tweet, TwitterUser } from "./api";
 
 function compactNumber(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
@@ -139,8 +139,8 @@ export function formatResearchMarkdown(
 /**
  * Format a user profile for Telegram.
  */
-export function formatProfileTelegram(user: any, tweets: Tweet[]): string {
-  const m = user.public_metrics || {};
+export function formatProfileTelegram(user: TwitterUser, tweets: Tweet[]): string {
+  const m = user.public_metrics ?? { followers_count: 0, following_count: 0, tweet_count: 0 };
   let out = `@${user.username} — ${user.name}\n`;
   out += `${compactNumber(m.followers_count || 0)} followers · ${compactNumber(m.tweet_count || 0)} tweets\n`;
   if (user.description) {


### PR DESCRIPTION
## Summary

Integrates 4 AI coding discipline rules from [luoling8192/ai-coding-principles](https://github.com/luoling8192/ai-coding-principles) into write-time enforcement, adds DDIA probes to plan blindspot review, and addresses desloppify review findings across the codebase.

Closes #55

- **Write-time discipline**: 4 advisory self-review items added to implementer agent (silent fallbacks, boundary-only catch, no lookup tables, debug log preservation) + lookup-table check in TDD per-cycle checklists
- **Review-time detection**: 2 new Tier 3 probes (default value masking, hardcoded lookup tables) in production failure patterns + 3 anti-pattern categories in code-quality-reviewer
- **Plan-time detection**: DDIA probes with relevance gate in both Codex and Gemini blindspot review critic prompts
- **Scoring rubric fix**: Error handling examples updated at all 4 levels to promote boundary-only catching (was contradicting discipline rules)
- **Code quality**: startServer() decomposed, exhaustive switch default, BraveOptions.result_filter applied, brave timeout configurable, runEval() extracted into runCase()+generateReport(), TwitterUser interface added
- **Adversarial review fixes**: Eval harness now emits synthetic failure on case errors (was silently passing), formatProfileTelegram shows "metrics unavailable" instead of fake zeros
- **Test coverage**: 102 new tests across 7 files (release, validate-versions, validate-plugin, run-eval, cache, format)
- **Desloppify score**: 18.7 → 85.4 strict

## Research

Based on `research/research-ai-coding-principles-learnings.md` (local, gitignored). Plan at `plans/ai-coding-discipline-integration.md` (local, gitignored). Blindspot reviewed by GPT-5.4-Codex. Adversarial code review by GPT-5.4-Codex.

## Files changed (20 files, +1615/-239)

| Area | Files | Change |
|------|-------|--------|
| Discipline rules | `agents/implementer.md`, `agents/code-quality-reviewer.md`, `skills/tdd/SKILL.md` | Write-time enforcement items |
| Review probes | `references/production-failure-patterns.md`, `references/blindspot-review-protocol.md` | DDIA + discipline probes |
| Scoring fix | `skills/.../scoring-rubric.md` | Boundary-only catch at all 4 levels |
| search-mcp | `index.ts`, `providers/brave.ts` | Decomposition, switch default, timeout, result_filter |
| x-search | `lib/api.ts`, `lib/format.ts` | TwitterUser type, metrics handling |
| eval | `run-eval.ts` | Extract runCase/generateReport, synthetic failure |
| scripts | `release.ts`, `validate-plugin.ts` | Exports, guards, JSON.parse fix |
| Tests | 7 new `*.test.ts` files | 102 tests |
| Config | `.gitignore`, `TODOS.md` | Housekeeping |

## Test plan

- [x] `bun run validate` passes
- [x] 102/102 tests pass across 6 test files
- [x] TypeScript type-check clean (no new errors)
- [x] Desloppify strict score 85.4/100 (target: 85.0)
- [x] Adversarial review: P1 and P3 findings addressed
- [ ] Manual: Run `/implement` on a task, verify 9-item self-review checklist appears
- [ ] Manual: Run `/plan` on data-intensive feature, verify DDIA probes in blindspot output