### PR TITLE
feat: rewrite interview skill for Opus 4.7 + add LLM-as-judge evals

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "sdlc-plugin",

--- a/eval/cases/interview-skill.eval.ts
+++ b/eval/cases/interview-skill.eval.ts
@@ -3,7 +3,7 @@ import { commonStructural } from '../shared-assertions.ts'
 
 const evalCase: EvalCase = {
   promptFile: 'skills/interview/SKILL.md',
-  description: 'Interview skill gathers requirements through structured questioning',
+  description: 'Interview skill walks decision tree with mandatory recommendations, one decision per round',
   structural: [
     ...commonStructural(),
     {
@@ -21,8 +21,81 @@ const evalCase: EvalCase = {
     {
       name: 'has-completion-section',
       test: (content) => /completion|when.*finish|after.*interview/i.test(content)
+    },
+    {
+      name: 'description-is-trigger-style',
+      test: (content) => /description:.*(Use when|Triggers when|when user)/i.test(content)
+    },
+    {
+      name: 'has-mandatory-recommendation',
+      test: (content) => /\(Recommended\)|mandatory recommendation|recommendation.*every round/i.test(content)
+    },
+    {
+      name: 'has-decision-tree-framing',
+      test: (content) => /decision.tree|branch.by.branch|unresolved.*branch|depth.first|walk.*branch/i.test(content)
+    },
+    {
+      name: 'has-one-decision-per-round',
+      test: (content) => /one decision per round|one.*question.*at a time|one\s+\*?\*?decision\*?\*?/i.test(content)
+    },
+    {
+      name: 'has-codebase-first-rule',
+      test: (content) => /codebase.*answer|explore.*don.t ask|Read\/Grep\/Glob|answerable.*code/i.test(content)
+    },
+    {
+      name: 'has-thinking-block',
+      test: (content) => /<thinking>/i.test(content)
+    },
+    {
+      name: 'has-example-block',
+      test: (content) => /<example>/i.test(content)
+    },
+    {
+      name: 'has-no-fabrication-rule',
+      test: (content) => /not fabricate|do not fabricate|surface.*ambiguity/i.test(content)
+    },
+    {
+      name: 'has-effort-guidance',
+      test: (content) => /xhigh|thinking effort|high.*effort/i.test(content)
+    },
+    {
+      name: 'has-opinionated-role',
+      test: (content) => /opinionated|challenge assumptions|senior engineer/i.test(content)
     }
-  ]
+  ],
+  testInput: 'I want to add OAuth authentication to my Node.js Express API. Interview me about this plan.',
+  judge: {
+    criteria: [
+      {
+        name: 'identifies-one-decision',
+        question: 'Does the output focus on exactly ONE decision for this round (rather than asking many questions at once)?'
+      },
+      {
+        name: 'offers-recommendation',
+        question: 'Does the output include an explicit recommendation marked "(Recommended)" or an equivalent clear recommendation among the options?'
+      },
+      {
+        name: 'cites-tradeoff',
+        question: 'Does the recommended option include a rationale that names a concrete tradeoff (e.g., performance, complexity, durability)?'
+      },
+      {
+        name: 'offers-alternatives',
+        question: 'Does the output present at least 2 alternatives besides the recommendation, each with its own tradeoff?'
+      },
+      {
+        name: 'opinionated-stance',
+        question: 'Does the output adopt an opinionated stance (senior-engineer reviewer style) rather than a passive neutral tone?'
+      },
+      {
+        name: 'targets-decision-branch',
+        question: 'Does the question target a specific design decision branch (e.g. token storage, session lifetime, provider choice) rather than a vague open-ended question?'
+      },
+      {
+        name: 'no-fabrication',
+        question: 'Does the output avoid making up specific codebase details (file names, package versions, existing code) that were not provided in the input?'
+      }
+    ]
+  }
 }
 
 export default evalCase

--- a/eval/cases/review.eval.ts
+++ b/eval/cases/review.eval.ts
@@ -7,12 +7,12 @@ const evalCase: EvalCase = {
   structural: [
     ...commonStructural(),
     {
-      name: 'has-codex-review-section',
-      test: (content) => /codex.*review/i.test(content)
+      name: 'has-codex-reviewer',
+      test: (content) => /codex.*(review|analyst|failure mode)/is.test(content)
     },
     {
-      name: 'has-gemini-review-section',
-      test: (content) => /gemini.*review/i.test(content)
+      name: 'has-gemini-reviewer',
+      test: (content) => /gemini.*(review|analyst|production)/is.test(content)
     },
     {
       name: 'mentions-parallel-execution',

--- a/eval/eval.config.ts
+++ b/eval/eval.config.ts
@@ -5,6 +5,10 @@ export const config = {
   model: 'claude-sonnet-4-5-20250929', // cheap + fast for eval
   maxTokens: 4096,
 
+  // Judge model — cheap grader for LLM-as-judge criteria
+  judgeModel: 'claude-haiku-4-5-20251001',
+  judgeMaxTokens: 1024,
+
   // Rate limiting
   maxRequestsPerMinute: 10,
 

--- a/eval/eval.types.ts
+++ b/eval/eval.types.ts
@@ -8,6 +8,17 @@ export interface BehavioralAssertion {
   test: (output: string) => boolean
 }
 
+/** A binary yes/no criterion graded by a judge model against LLM output. */
+export interface JudgeCriterion {
+  name: string
+  /** Yes/no question the judge answers about the output. */
+  question: string
+}
+
+export interface JudgeConfig {
+  criteria: JudgeCriterion[]
+}
+
 export interface EvalCase {
   /** Which prompt file this tests (relative to sdlc-plugin/) */
   promptFile: string
@@ -17,6 +28,8 @@ export interface EvalCase {
   structural: StructuralAssertion[]
   /** Behavioral assertions checked against LLM output (optional, requires API key) */
   behavioral?: BehavioralAssertion[]
+  /** LLM-as-judge criteria graded against LLM output (optional, requires API key) */
+  judge?: JudgeConfig
   /** Test input to feed the model along with the prompt (for behavioral evals) */
   testInput?: string
 }

--- a/eval/run-eval.test.ts
+++ b/eval/run-eval.test.ts
@@ -206,4 +206,44 @@ describe("runCase", () => {
     expect(result.results[0].assertion).toBe("case_execution");
     expect(result.cost).toBe(0);
   });
+
+  test("EvalCase accepts optional judge field with criteria", () => {
+    // Type-level verification — if this compiles, the shape is valid
+    const evalCase: EvalCase = {
+      promptFile: "skills/interview/SKILL.md",
+      description: "judge shape check",
+      structural: [],
+      judge: {
+        criteria: [
+          { name: "has-recommendation", question: "Did the output include a recommendation?" },
+          { name: "surfaces-tradeoffs", question: "Did the output cite a tradeoff for each option?" },
+        ],
+      },
+      testInput: "Interview me about adding OAuth.",
+    };
+    expect(evalCase.judge?.criteria).toHaveLength(2);
+    expect(evalCase.judge?.criteria[0].name).toBe("has-recommendation");
+  });
+
+  test("llm mode skips judge when no anthropic client provided", async () => {
+    const evalCase: EvalCase = {
+      promptFile: "__nonexistent__.md",
+      description: "judge without API key",
+      structural: [],
+      judge: {
+        criteria: [{ name: "any", question: "Any?" }],
+      },
+      testInput: "test",
+    };
+
+    const result = await runCase(evalCase, {
+      mode: "llm",
+      anthropic: null,
+      totalCost: 0,
+    });
+
+    // No judge results when client absent — file read fails first, synthetic error only
+    const judgeResults = result.results.filter((r) => r.assertion.startsWith("judge:"));
+    expect(judgeResults).toHaveLength(0);
+  });
 });

--- a/eval/run-eval.ts
+++ b/eval/run-eval.ts
@@ -117,78 +117,170 @@ function runStructuralAssertions(
   return results
 }
 
-// Run behavioral assertions (requires API)
-async function runBehavioralAssertions(
+// Generate output once, shared between behavioral regex + judge
+async function generateOutput(
   evalCase: EvalCase,
   promptContent: string,
   anthropic: Anthropic
-): Promise<{ results: EvalResult[]; cost: number }> {
+): Promise<{ output: string; cost: number }> {
+  const userMessage = evalCase.testInput || 'Test input'
+  const fullPrompt = `${promptContent}\n\n---\n\n${userMessage}`
+
+  const response = await anthropic.messages.create({
+    model: config.model,
+    max_tokens: config.maxTokens,
+    messages: [{ role: 'user', content: fullPrompt }]
+  })
+
+  const output = response.content
+    .filter(block => block.type === 'text')
+    .map(block => (block as { type: 'text'; text: string }).text)
+    .join('\n')
+
+  // Sonnet 4.5: $3/MTok input, $15/MTok output
+  const cost = (response.usage.input_tokens / 1_000_000 * 3) +
+               (response.usage.output_tokens / 1_000_000 * 15)
+
+  return { output, cost }
+}
+
+// Run regex behavioral assertions against a pre-generated output
+function runBehavioralAssertionsOnOutput(
+  evalCase: EvalCase,
+  output: string
+): EvalResult[] {
   const results: EvalResult[] = []
+  if (!evalCase.behavioral) return results
 
-  if (!evalCase.behavioral || evalCase.behavioral.length === 0) {
-    return { results, cost: 0 }
-  }
-
-  try {
-    // Call Anthropic API with prompt
-    const userMessage = evalCase.testInput || 'Test input'
-    const fullPrompt = `${promptContent}\n\n---\n\n${userMessage}`
-
-    const response = await anthropic.messages.create({
-      model: config.model,
-      max_tokens: config.maxTokens,
-      messages: [{
-        role: 'user',
-        content: fullPrompt
-      }]
-    })
-
-    // Extract text output
-    const output = response.content
-      .filter(block => block.type === 'text')
-      .map(block => (block as { type: 'text'; text: string }).text)
-      .join('\n')
-
-    // Calculate cost (Sonnet 4.5: $3/MTok input, $15/MTok output)
-    const inputTokens = response.usage.input_tokens
-    const outputTokens = response.usage.output_tokens
-    const cost = (inputTokens / 1_000_000 * 3) + (outputTokens / 1_000_000 * 15)
-
-    // Run assertions against output
-    for (const assertion of evalCase.behavioral) {
-      try {
-        const passed = assertion.test(output)
-        results.push({
-          promptFile: evalCase.promptFile,
-          description: evalCase.description,
-          mode: 'behavioral',
-          assertion: assertion.name,
-          passed,
-          details: passed ? undefined : 'Assertion failed'
-        })
-      } catch (error) {
-        results.push({
-          promptFile: evalCase.promptFile,
-          description: evalCase.description,
-          mode: 'behavioral',
-          assertion: assertion.name,
-          passed: false,
-          details: `Error: ${error instanceof Error ? error.message : String(error)}`
-        })
-      }
-    }
-
-    return { results, cost }
-  } catch (error) {
-    // API call failed
-    for (const assertion of evalCase.behavioral) {
+  for (const assertion of evalCase.behavioral) {
+    try {
+      const passed = assertion.test(output)
+      results.push({
+        promptFile: evalCase.promptFile,
+        description: evalCase.description,
+        mode: 'behavioral',
+        assertion: assertion.name,
+        passed,
+        details: passed ? undefined : 'Assertion failed'
+      })
+    } catch (error) {
       results.push({
         promptFile: evalCase.promptFile,
         description: evalCase.description,
         mode: 'behavioral',
         assertion: assertion.name,
         passed: false,
-        details: `API Error: ${error instanceof Error ? error.message : String(error)}`
+        details: `Error: ${error instanceof Error ? error.message : String(error)}`
+      })
+    }
+  }
+
+  return results
+}
+
+// Run LLM-as-judge criteria against generated output
+async function runJudgeAssertions(
+  evalCase: EvalCase,
+  output: string,
+  anthropic: Anthropic
+): Promise<{ results: EvalResult[]; cost: number }> {
+  const results: EvalResult[] = []
+
+  if (!evalCase.judge || evalCase.judge.criteria.length === 0) {
+    return { results, cost: 0 }
+  }
+
+  const criteriaList = evalCase.judge.criteria
+    .map((c, i) => `${i + 1}. [${c.name}] ${c.question}`)
+    .join('\n')
+
+  const judgePrompt = `You are grading the output of a skill against a rubric.
+
+<output>
+${output}
+</output>
+
+<rubric>
+For each numbered criterion below, answer PASS or FAIL based strictly on what is visible in the output above. Do not infer or give benefit of the doubt.
+
+${criteriaList}
+</rubric>
+
+Respond with ONLY a JSON object mapping each criterion name to "PASS" or "FAIL". Example:
+{"criterion-name-1": "PASS", "criterion-name-2": "FAIL"}`
+
+  try {
+    const response = await anthropic.messages.create({
+      model: config.judgeModel,
+      max_tokens: config.judgeMaxTokens,
+      messages: [{ role: 'user', content: judgePrompt }]
+    })
+
+    const judgeText = response.content
+      .filter(block => block.type === 'text')
+      .map(block => (block as { type: 'text'; text: string }).text)
+      .join('\n')
+
+    // Haiku 4.5: $1/MTok input, $5/MTok output (approximate)
+    const cost = (response.usage.input_tokens / 1_000_000 * 1) +
+                 (response.usage.output_tokens / 1_000_000 * 5)
+
+    // Extract JSON from judge response (tolerate surrounding prose)
+    const jsonMatch = judgeText.match(/\{[\s\S]*\}/)
+    if (!jsonMatch) {
+      for (const criterion of evalCase.judge.criteria) {
+        results.push({
+          promptFile: evalCase.promptFile,
+          description: evalCase.description,
+          mode: 'behavioral',
+          assertion: `judge:${criterion.name}`,
+          passed: false,
+          details: `Judge returned no JSON: ${judgeText.slice(0, 200)}`
+        })
+      }
+      return { results, cost }
+    }
+
+    let verdicts: Record<string, string>
+    try {
+      verdicts = JSON.parse(jsonMatch[0])
+    } catch (err) {
+      for (const criterion of evalCase.judge.criteria) {
+        results.push({
+          promptFile: evalCase.promptFile,
+          description: evalCase.description,
+          mode: 'behavioral',
+          assertion: `judge:${criterion.name}`,
+          passed: false,
+          details: `Judge JSON parse error: ${err instanceof Error ? err.message : String(err)}`
+        })
+      }
+      return { results, cost }
+    }
+
+    for (const criterion of evalCase.judge.criteria) {
+      const verdict = verdicts[criterion.name]
+      const passed = verdict === 'PASS'
+      results.push({
+        promptFile: evalCase.promptFile,
+        description: evalCase.description,
+        mode: 'behavioral',
+        assertion: `judge:${criterion.name}`,
+        passed,
+        details: passed ? undefined : `Judge verdict: ${verdict ?? 'missing'}`
+      })
+    }
+
+    return { results, cost }
+  } catch (error) {
+    for (const criterion of evalCase.judge.criteria) {
+      results.push({
+        promptFile: evalCase.promptFile,
+        description: evalCase.description,
+        mode: 'behavioral',
+        assertion: `judge:${criterion.name}`,
+        passed: false,
+        details: `Judge API error: ${error instanceof Error ? error.message : String(error)}`
       })
     }
     return { results, cost: 0 }
@@ -236,8 +328,10 @@ export async function runCase(evalCase: EvalCase, opts: RunCaseOpts): Promise<Ru
       console.log(`  Structural: ${passed} passed, ${failed} failed`)
     }
 
-    // Run behavioral assertions
-    if ((mode === 'llm' || mode === 'all') && anthropic && evalCase.behavioral) {
+    // Run behavioral + judge (share one generated output)
+    const needsOutput = (mode === 'llm' || mode === 'all') && anthropic &&
+                        (evalCase.behavioral || evalCase.judge)
+    if (needsOutput) {
       // Check spend guard
       if (totalCost >= config.maxSpendPerRun) {
         console.warn(`  ⚠️  Spend limit reached ($${config.maxSpendPerRun}). Skipping LLM eval.`)
@@ -245,20 +339,65 @@ export async function runCase(evalCase: EvalCase, opts: RunCaseOpts): Promise<Ru
         return { results: caseResults, cost: 0, skipped: true }
       }
 
-      // Rate limit
+      // Rate limit before generation call
       await rateLimit(config.maxRequestsPerMinute)
 
-      const { results: behavioralResults, cost } = await runBehavioralAssertions(
-        evalCase,
-        content,
-        anthropic
-      )
-      caseResults.push(...behavioralResults)
-      caseCost = cost
+      try {
+        const { output, cost: genCost } = await generateOutput(evalCase, content, anthropic!)
+        caseCost += genCost
 
-      const passed = behavioralResults.filter(r => r.passed).length
-      const failed = behavioralResults.filter(r => !r.passed).length
-      console.log(`  Behavioral: ${passed} passed, ${failed} failed (cost: $${cost.toFixed(4)})`)
+        // Regex behavioral
+        if (evalCase.behavioral) {
+          const behavioralResults = runBehavioralAssertionsOnOutput(evalCase, output)
+          caseResults.push(...behavioralResults)
+          const passed = behavioralResults.filter(r => r.passed).length
+          const failed = behavioralResults.filter(r => !r.passed).length
+          console.log(`  Behavioral: ${passed} passed, ${failed} failed`)
+        }
+
+        // LLM-as-judge
+        if (evalCase.judge) {
+          await rateLimit(config.maxRequestsPerMinute)
+          const { results: judgeResults, cost: judgeCost } = await runJudgeAssertions(
+            evalCase,
+            output,
+            anthropic!
+          )
+          caseResults.push(...judgeResults)
+          caseCost += judgeCost
+          const passed = judgeResults.filter(r => r.passed).length
+          const failed = judgeResults.filter(r => !r.passed).length
+          console.log(`  Judge: ${passed} passed, ${failed} failed`)
+        }
+
+        console.log(`  LLM cost: $${caseCost.toFixed(4)}`)
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error)
+        if (evalCase.behavioral) {
+          for (const assertion of evalCase.behavioral) {
+            caseResults.push({
+              promptFile: evalCase.promptFile,
+              description: evalCase.description,
+              mode: 'behavioral',
+              assertion: assertion.name,
+              passed: false,
+              details: `API Error: ${msg}`
+            })
+          }
+        }
+        if (evalCase.judge) {
+          for (const criterion of evalCase.judge.criteria) {
+            caseResults.push({
+              promptFile: evalCase.promptFile,
+              description: evalCase.description,
+              mode: 'behavioral',
+              assertion: `judge:${criterion.name}`,
+              passed: false,
+              details: `API Error: ${msg}`
+            })
+          }
+        }
+      }
     }
   } catch (error) {
     console.error(`  ✗ Error: ${error instanceof Error ? error.message : String(error)}`)

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: interview
-description: Interview me about anything in depth
+description: Conducts depth-first interview walking a plan's decision tree with mandatory recommendations. Use when user wants to stress-test a design, get grilled on a plan, or says "interview me" / "grill me" / "walk me through this".
 argument-hint: [topic or file]
 model: opus
 ---
@@ -10,38 +10,75 @@ model: opus
 ## Priorities
 
 ```
-Insight > Brevity > Closure
+Insight > Depth > Brevity > Closure
 ```
 
-## Goal
+## Role
 
-Conduct iterative interviews about topics or files. For files, detect paths (contains `/`, `.md`, `.ts`) and read first. Interview round-by-round with AskUserQuestion until user says "done" or coverage is sufficient.
+Act as a senior engineer reviewing the user's plan. Opinionated, not passive. Challenge assumptions. Surface missing branches. Force concrete decisions by offering a recommendation every round.
 
-## Constraints
+## Effort
 
-- Use AskUserQuestion with multiple-choice options for fast responses
-- Include "(Recommended)" option when you have a strong opinion
-- Include "Not sure - you decide" escape hatch for low-stakes decisions
-- Ask 1-4 questions per round
-- Ask about tradeoffs, edge cases, scope, preferences, constraints, alternatives
-- Never ask obvious things, surface-level questions, or things answerable by code discovery
-- Add footer for power users: `Reply format: 1a 2b or defaults`
+Run at `high` or `xhigh` thinking effort. Long-horizon branching reasoning justifies the budget; lower effort produces shallow follow-ups.
+
+## Loop
+
+Apply these rules every round, on every branch — do not generalize from the first round alone.
+
+1. <thinking>Identify the next unresolved decision branch. Note dependencies on branches already resolved. Ask: can the codebase answer this? If yes, explore with Read/Grep/Glob — do not ask the user.</thinking>
+2. Formulate **one decision** per round. Present via `AskUserQuestion` with:
+   - Your recommendation marked `(Recommended)` plus a one-line rationale citing the tradeoff
+   - 2–3 alternatives, each with its tradeoff
+   - `Not sure - you decide` escape hatch for low-stakes choices
+3. On answer: descend into dependent branches. Repeat from step 1.
+4. If the codebase is ambiguous or contradictory, surface the ambiguity. Do not fabricate.
+
+Footer every round: `Reply format: 1a 2b or defaults`
+
+## Input Handling
+
+- Path detected (contains `/`, `.md`, `.ts`, `.tsx`, etc.) — Read the file first, then interview about its decisions.
+- Topic string — interview directly.
 
 ## Question Categories
 
-1. Technical Implementation - Architecture, technology choices, data flow
-2. User Experience - Interaction patterns, error states, edge cases
-3. Constraints & Requirements - Performance, security, scalability
-4. Scope & Priorities - Must-have vs nice-to-have, first version vs future
-5. Risks & Concerns - What could go wrong, uncertainties, alternatives
+Draw from these when picking the next branch. Do not rotate mechanically; follow the decision tree's dependencies.
+
+1. Technical implementation — architecture, data flow, technology choices
+2. User experience — interaction patterns, error states, edge cases
+3. Constraints & requirements — performance, security, scalability, scope
+4. Scope & priorities — must-have vs nice-to-have, v1 vs future
+5. Risks & alternatives — what breaks, what was ruled out and why
+
+Skip obvious questions. Skip anything answerable by code discovery.
+
+## Example Round
+
+<example>
+<thinking>
+Current branch: session token storage. Depends on session-lifetime branch (resolved: 24h).
+Check codebase first — is a session store already wired?
+</thinking>
+
+Reads `src/auth/session.ts` via Grep/Read. No store found. Redis already in stack (`package.json`).
+
+Calls `AskUserQuestion`:
+- Question: "Where should session tokens live?"
+- Options:
+  - `(Recommended) Redis` — already in stack, native TTL matches 24h expiry
+  - `Postgres` — durable across restarts, slower reads
+  - `JWT stateless` — no store but loses server-side revocation
+  - `Not sure - you decide`
+
+Footer: `Reply format: 1a 2b or defaults`
+</example>
 
 ## Completion
 
-When user says "done" or all areas explored:
+Stop when the user says "done" or all branches are resolved.
 
-**File input**: Update original file with refined information. Add "Interview Insights" section preserving structure.
-
-**Topic input**: Provide comprehensive summary of insights, key decisions, and unresolved questions.
+- **File input** — append an `## Interview Insights` section to the original file. Preserve existing structure. Record resolved decisions, rejected alternatives, and open questions.
+- **Topic input** — summarize resolved decisions with their tradeoffs, and list any open questions.
 
 ## Topic
 


### PR DESCRIPTION
## Summary

- **Interview skill rewrite**: decision-tree traversal, mandatory recommendations, `<thinking>` reasoning, codebase-first rule, no-fabrication guardrail. Aligned with Anthropic's Opus 4.7 guidance (literal instruction following, calibrated length, `xhigh` effort).
- **LLM-as-judge eval infrastructure**: optional `judge.criteria` on any `EvalCase`, graded by Haiku 4.5 with binary PASS/FAIL verdicts. Shares one Sonnet generation call between regex behavioral asserts and judge.
- **Interview eval expanded**: +10 structural asserts for new rules, +7 judge criteria for semantic quality (one-decision focus, recommendation presence, tradeoff rationale, alternatives, opinionated stance, decision-branch targeting, no fabrication).
- **Fix stale review.md regex**: `has-codex-review-section` / `has-gemini-review-section` asserts went stale after the adversarial-review refactor; widened vocabulary + dotall.

## Context

External `grill-me` skill was performing well for the user — walks design decision tree one branch at a time with mandatory recommendations. Merged that pattern into our `interview` skill while keeping our `AskUserQuestion` multi-choice UX and file-mode completion. Opus 4.7 best practices pulled from Anthropic's prompt engineering docs, Opus 4.7 release notes, and skill authoring guide.

Regex-only structural evals were catching rule deletion but not stance/format drift. Added LLM-as-judge for the interview skill so monthly regression runs catch semantic regressions too.

## Commits

1. `feat(eval)`: LLM-as-judge grading infrastructure
2. `feat(skills)`: rewrite interview for Opus 4.7 decision-tree interviews
3. `fix(eval)`: update review.md reviewer asserts after adversarial refactor

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun test eval/` — 6/6 self-test pass, 16/16 run-eval tests pass
- [x] `bun run eval --mode structural` — 176/176 assertions pass (was 174/176 on main)
- [x] `bun run validate` — plugin manifest valid
- [ ] Manual: run `ANTHROPIC_API_KEY=... bun run eval --mode llm --filter interview` to baseline judge scores (~\$0.03)
- [ ] Manual: invoke `/interview` on a real plan to sanity-check the new decision-tree flow

## Costs

- Monthly eval run: Sonnet generation ~\$0.02 + Haiku judge ~\$0.005 = **~\$0.025 per interview case**
- Spend guard unchanged at \$5/run