### PR TITLE
refactor: Opus 4.7 prompt refactor (v1.29.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations for enhanced software development workflow",
   "author": {
     "name": "Ladislav Martincik",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the SDLC Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.29.0] - 2026-04-18
+
+### Added
+- `OPUS_4_7_PROMPTING.md` — canonical workspace reference for writing prompts that get the best out of Claude Opus 4.7. Covers 12 principles (onboarding structure, explain-why, drop compensation phrases, find/filter split, etc.), the breaking-change checklist (removed `temperature`/`top_p`/`top_k`/`budget_tokens`/prefill), before/after examples, and primary source URLs. Referenced by system-prompt-clinic.
+
+### Changed
+- `commands/research-deep.md` rewritten for Opus 4.7 (283 → 163 lines). Collapsed Step 1-7 scaffolding into goal + cleanup invariant; flattened swarm/standard branching; stripped `CRITICAL`/`MUST`/`DO NOT` in favor of reasoned prose.
+- `commands/implement.md` rewritten for Opus 4.7 (292 → 198 lines). Replaced subagent workflow step-list with role + success criteria; implementers trusted with TDD reference docs directly rather than pre-digested rule bullets.
+- `commands/research.md` rewritten for Opus 4.7 (197 → 140 lines). Cleaned routing logic; replaced `YOUR ONLY JOB` caps-wall with reasoned scope paragraph.
+- `commands/plan.md` rewritten for Opus 4.7 (151 → 106 lines). Compressed Constraints block; folded each rule's rationale into the relevant checkpoint.
+- `skills/judgment-eval/SKILL.md` rewritten for Opus 4.7 (202 → 167 lines). Restructured as role + effort + scope; added find/filter discipline so 4.7 doesn't suppress surprising-but-defensible observations during evaluation.
+- `skills/system-prompt-clinic/SKILL.md` rewritten for Opus 4.7 (188 → 167 lines). Aligned with `OPUS_4_7_PROMPTING.md` as canonical reference; added dedicated "Opus 4.7 alignment" section covering the breaking-change checklist.
+- `agents/research-synthesizer.md` — "NEVER organize top-level sections by source LLM" rephrased with rationale (thematic > per-source for consensus surfacing).
+- `references/blindspot-review-protocol.md` — softened `IMPORTANT`/`CRITICAL` gates with reason-attached prose.
+- `skills/gemini/SKILL.md` + `gemini-cli-reference.md` — `NEVER`/`ALWAYS` on approval-mode replaced with reasoned hang-on-stdin explanation.
+
 ## [1.28.0] - 2026-04-13
 
 ### Added

--- a/OPUS_4_7_PROMPTING.md
+++ b/OPUS_4_7_PROMPTING.md
@@ -1,0 +1,214 @@
+# Prompting for Claude Opus 4.7
+
+This is the workspace reference for writing prompts (commands, agents, skills) that get the best out of Claude Opus 4.7. It exists because prompts tuned for 4.5/4.6 and earlier often *actively hurt* output quality on 4.7 — not by a little, but enough to suppress findings, over-trigger tools, or flatten reasoning. If you're writing or editing any prompt file in this workspace, read this first.
+
+Canonical reference files — when in doubt, model after these:
+- `sdlc-plugin/skills/interview/SKILL.md` — onboarding-doc structure, `<thinking>` example
+- `sdlc-plugin/commands/review.md` — evidence-backed protocol, find-then-filter split
+- `sdlc-plugin/agents/implementer.md` — lean role + success criteria
+- `primitives-plugin/skills/prompt-as-onboarding/SKILL.md` — canonical onboarding-doc skill
+- `primitives-plugin/skills/de-slop/SKILL.md` — tool-delegation pattern
+
+## Why this document exists
+
+Opus 4.7 is not Opus 4.6 with more horsepower. Three shifts matter for prompt design:
+
+1. **It reasons more, and earlier.** It trends toward fewer tool calls and more internal deliberation. Scaffolding that nudged earlier models to "think harder" now creates noise or inconsistent behavior.
+2. **It's more literal.** It does not silently generalize an instruction from the first item to the rest of a list, and it does not infer requests you didn't make. Implicit generalization that worked on 4.6 now leaves work undone.
+3. **API surface changed.** `temperature`, `top_p`, `top_k`, `budget_tokens`, and assistant-message prefill all return 400. Behavior shaping moves fully into the prompt. Effort (not `budget_tokens`) is the intelligence dial.
+
+What follows are the principles those shifts imply, with the reasoning so you can judge edge cases we haven't seen yet.
+
+## Principles
+
+### 1. Write prompts as onboarding documents, not rule lists.
+
+Open with role → why this role exists → what success looks like. Then reasoning examples. Then edge cases. Rule-lists ("you MUST do X; you MUST NEVER do Y") generalize worse than reasoned prose because 4.7 follows the spirit of a principle, and spirit needs a reason attached.
+
+**Why:** The Claude Constitution (Anthropic, Jan 2026, CC0) and the 4.7 prompting docs both show broad, reasoned principles outperform command lists. Threat-framed or caps-locked rules correlate with brittle behavior under edge cases that the rule didn't anticipate.
+
+### 2. Explain *why* inline with every constraint.
+
+Compare:
+- ❌ "Never mock the database in integration tests."
+- ✅ "Don't mock the database in integration tests — last quarter mocked tests passed while the prod migration broke, which is exactly the class of bug integration tests exist to catch."
+
+**How to apply:** If removing the *why* would leave the reader unable to judge an edge case, the *why* needs to be there.
+
+### 3. State scope explicitly.
+
+4.7 will not generalize "apply this formatting" to every section unless you say so. If you want a rule applied to a list, say "for every item" or "across all sections." If you want the model to fan out, say "for each." Assume nothing carries implicitly.
+
+### 4. Drop compensation phrases.
+
+Remove "think step by step", "take your time", "be thorough", "carefully consider." These compensated for pre-4.x reasoning gaps that `effort` now closes at the API level. Leaving them in adds noise and token waste.
+
+**If you need deeper reasoning:** raise `effort` to `high` or `xhigh` and say so in the prompt ("Run at `high` thinking effort — long-horizon branching reasoning justifies the budget"). Don't chant.
+
+### 5. Don't weaponize capitals.
+
+`CRITICAL:`, `MUST`, `NEVER`, `IMPORTANT` used as rule-emphasis are noise. 4.7 treats reasoned prose with the same weight as caps-walls — and caps-walls with threatening tone ("or users will be harmed") actively degrade generalization.
+
+**Keep caps for:**
+- Genuinely destructive operations the user needs to see before approving (real warnings).
+- Quoting error messages verbatim.
+- Protocol names / IDs that happen to be capitalized.
+
+### 6. Remove defensive step-numbering where the model can plan.
+
+"Step 1 do X. Step 2 do Y. Step 3 do Z." invites over-triggering — the model follows the literal sequence even when a step doesn't apply. State the goal and the invariants; let the model pick the path.
+
+**Keep step-numbering only where sequence correctness is load-bearing** — e.g., team-cleanup ordering where skipping a step leaks resources. In that case, explain the invariant too ("the team must be deleted before returning control, regardless of success/failure — skipping leaks slots").
+
+### 7. Separate find from filter in review and audit prompts.
+
+4.7 follows "report only high-severity issues" faithfully and will suppress findings you'd have wanted. Split the pipeline:
+
+```
+Find stage: report every issue with confidence and severity attached.
+Filter stage: downstream pass drops low-confidence or low-severity findings.
+```
+
+This is why `sdlc-plugin/commands/review.md` reports everything in its divergent-reviews phase, then cross-examines in a separate phase.
+
+### 8. Cite evidence when recommending a pattern.
+
+"Do X because a study across 3,700 trials on 5 frontier models found a 13% → 100% bug-catch delta when Y was applied" beats "do X because it's good practice." 4.7 grounds its own behavior better when the prompt is grounded too. See `sdlc-plugin/commands/review.md` for the template.
+
+### 9. Trust tool output; don't replicate tool logic.
+
+If you delegate to `desloppify`, `codex`, `gemini`, `update-models` — trust what they return. Don't include prose that second-guesses their output or re-implements their logic "just in case." The `de-slop` skill is the reference: it delegates cleanly and falls back only when the tool is unavailable.
+
+### 10. Parallel tool calls: be explicit when needed.
+
+4.7 defaults to fewer, more sequential tool calls. For tasks where fan-out matters (reading many files, spawning independent subagents), include a one-liner:
+
+```
+If you intend to call multiple tools and there are no dependencies between them, make all independent calls in parallel.
+```
+
+Don't include this by default — it's only earning its keep where fan-out is the whole point.
+
+### 11. Anti-preamble in system prompt.
+
+Prefill is gone (returns 400 on 4.7). Replace any reliance on prefill with a system-prompt line:
+
+```
+Respond directly without preamble. Don't start with "Here is…", "Based on…", "Sure,…", or similar.
+```
+
+This is also why "no sycophantic openers" lives in HAL's global CLAUDE.md — it's the successor to prefill.
+
+### 12. Use XML tags for mixed-content prompts.
+
+For long commands that mix instructions, context, examples, and constraints (`implement.md`, `research-deep.md`, `review.md`), XML tags reduce misread:
+
+```xml
+<role>…</role>
+<success-criteria>…</success-criteria>
+<examples>
+  <example>…</example>
+</examples>
+<invariants>…</invariants>
+```
+
+Short prompts don't need this — prose sections are fine. Reach for tags when the same file contains more than three distinct instruction types.
+
+## Breaking changes to scrub from older prompts
+
+If you're migrating a pre-4.7 prompt, check for these:
+
+| Pattern | What to do |
+|---|---|
+| `temperature`, `top_p`, `top_k` in any SDK call | Remove — returns 400 on 4.7. |
+| `budget_tokens` in thinking config | Remove — use `effort` parameter instead. |
+| Assistant-message prefill | Remove — returns 400. Replace with system-prompt "respond directly" line. |
+| "think step by step", "take your time" | Remove. Raise `effort` if depth is needed. |
+| Hardcoded model IDs (`claude-opus-4-5-20250929`, etc.) | Replace with registry-resolved aliases (`opus`, `sonnet`, `haiku`). |
+| Hardcoded `max_tokens` budgets | Re-check — 4.7 tokenizer produces ~1x–1.35x more tokens per unit text. |
+| "CRITICAL: ALWAYS use tool X" | Rewrite as "Use tool X when [condition]; skip when [condition]." |
+| Post-every-N-calls "summarize progress" scaffolding | Remove — 4.7 already narrates progress in agentic traces. |
+
+## Before / after examples
+
+### Example A — command (research routing)
+
+Before (rule-heavy, 4.6-style):
+
+```markdown
+## CRITICAL: Route Selection
+
+BEFORE taking any other action, check `$ARGUMENTS` for the `--no-swarm` flag:
+
+1. If `--no-swarm` IS present: remove it from the arguments (the remaining text
+   is the research topic), then skip directly to **Standard Workflow**. Do NOT
+   execute any Swarm Workflow steps.
+2. If `--no-swarm` is NOT present: the full `$ARGUMENTS` is the research topic,
+   skip directly to **Swarm Workflow**. Do NOT execute any Standard Workflow steps.
+
+If no research topic remains after processing, ask the user for a research
+question before proceeding.
+```
+
+After (reasoning-based, 4.7-native):
+
+```markdown
+## Routing
+
+Swarm is the default — research usually benefits from teammates sharing discoveries in real time. If the user passes `--no-swarm`, strip the flag and run the standard solo workflow instead. If the remaining topic is empty, ask for a research question rather than guessing.
+```
+
+Shorter, less forceful, same semantics. The model owns the branching.
+
+### Example B — skill (review stage split)
+
+Before (single-stage, will suppress findings on 4.7):
+
+```markdown
+Review the PR. Report only high-severity issues that definitely need to be fixed.
+Filter out anything minor.
+```
+
+After (find / filter split):
+
+```markdown
+## Find stage
+
+Report every issue you notice, including low-confidence ones. For each finding:
+- severity: blocker | major | minor | nit
+- confidence: high | medium | low
+- one-line reasoning
+
+Don't filter at this stage — coverage matters here, precision comes next.
+
+## Filter stage
+
+From the findings list, surface to the user:
+- All blockers (any confidence)
+- Majors with confidence ≥ medium
+- Nits grouped together, one line each
+```
+
+Separating stages stops 4.7 from silently dropping findings it thought were "not important enough."
+
+## Source URLs
+
+Anthropic primary sources:
+- [What's new in Claude Opus 4.7](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7)
+- [Migration guide (4.6 → 4.7 and 4.5 → 4.7)](https://platform.claude.com/docs/en/about-claude/models/migration-guide)
+- [Prompting best practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices)
+- [Adaptive thinking](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking)
+- [Extended thinking tips](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/extended-thinking-tips)
+- [Effort parameter](https://platform.claude.com/docs/en/build-with-claude/effort)
+- [Task budgets (beta)](https://platform.claude.com/docs/en/build-with-claude/task-budgets)
+- [Introducing Claude Opus 4.7](https://www.anthropic.com/news/claude-opus-4-7)
+- [Claude's Constitution (Jan 2026, CC0)](https://www.anthropic.com/news/claudes-constitution)
+
+## How this document is used
+
+- Anyone writing or editing a prompt in this workspace — read this first.
+- The `system-prompt-clinic` skill references these principles when transforming rule-based prompts.
+- The `constitution-compliance-review` skill scores prompts against a superset of these principles.
+- When in doubt: read `sdlc-plugin/skills/interview/SKILL.md` and `sdlc-plugin/commands/review.md` and model the style.
+
+Prompts age. If you find a principle here that's been superseded by later guidance from Anthropic, update this file — it's the canonical reference, so the canonical reference is the one that gets fixed.

--- a/agents/research-synthesizer.md
+++ b/agents/research-synthesizer.md
@@ -13,14 +13,14 @@ Completeness (preserve all findings) > Accuracy (correct attribution) > Organiza
 ## Goal
 Merge 2+ research reports on the same topic into one comprehensive document organized by **theme**, not by source LLM. Identify consensus findings (appearing in multiple reports), unique discoveries (from one report only), areas of disagreement, and novel insights that emerged from cross-pollination refinement. Use inline LLM attribution markers to track provenance within themed sections.
 
-## Constraints
-- Read all research reports before merging
-- Organize findings by **theme/topic area** — NEVER organize top-level sections by source LLM
-- Use inline LLM attribution markers: `[Consensus: 3/3]`, `[Consensus: 2/3]`, `[Claude]`, `[Gemini]`, `[Codex]`
-- Preserve ALL file:line references from all reports
-- Don't editorialize — merge objectively
-- Prefer refined reports (`*-refined.md`) over originals (`*-analysis.md`) when both exist
-- When comparing refined vs original versions, note findings that are NEW in the refined version — these represent cross-pollination insights
+## How to merge
+
+- Read all research reports before you start merging — you can't weigh consensus without the full set.
+- Organize top-level sections by **theme/topic area**, not by source LLM. Source-LLM sections force the reader to re-merge in their head and obscure consensus; thematic sections surface agreement and disagreement directly.
+- Use inline LLM attribution on findings inside each thematic section: `[Consensus: 3/3]`, `[Consensus: 2/3]`, `[Claude]`, `[Gemini]`, `[Codex]`.
+- Preserve every `file:line` reference from the source reports — they're the provenance readers will check.
+- Don't editorialize. Merge objectively; let the consensus markers speak to confidence.
+- Prefer refined reports (`*-refined.md`) over originals (`*-analysis.md`) when both exist. Flag findings that appear in the refined version but not the original — those are the cross-pollination insights worth highlighting.
 
 ## Output
 Produce a single markdown document with YAML frontmatter and structured sections.

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -1,292 +1,198 @@
 # Implement the following plan
 
+## Role
+
+You orchestrate subagent-driven implementation of a plan: dispatch fresh `implementer` agents per task, gate each task through `spec-reviewer` then `code-quality-reviewer`, keep the todo list synced with GitHub Issue checkboxes, and make atomic commits per task. Implementers execute — you coordinate.
+
 ## Priorities
 
 Correctness (spec compliance) > Progress (forward momentum) > Efficiency (minimal context use)
 
-## Goal
+## Pre-flight
 
-Execute plan using **subagent-driven development**: dispatch fresh implementer agents per task, validate with two-stage review (spec-reviewer → code-quality-reviewer), progress tracking via todo list, update Issue checkboxes.
+- `/rename "Implement: #$ARGUMENTS"` (issue number) or `/rename "Implement: {plan-name}"`.
+- Read CLAUDE.md for `tdd:` mode (`strict` / `soft` / `off`) — pass this to every implementer.
+- `git branch --show-current`. If on main, run `SlashCommand(/p:generate_branch)`.
 
-## Constraints
+## Input parsing
 
-### Pre-flight
-Rename session: `/rename "Implement: #$ARGUMENTS"` or `/rename "Implement: {plan-name}"`.
+`$ARGUMENTS` carries a plan reference and optional flags. Strip `--swarm` if present (it selects the swarm branch below). The remainder is either an issue number (`#123`) or a plan file path.
 
-Check TDD Mode: Read CLAUDE.md for `tdd:` (strict/soft/off). Pass to implementer agents.
+- **Issue**: `gh issue view #123 --json body` → extract the plan path from the body → read the file fully.
+- **File**: read the plan's frontmatter for an associated Issue. If none, stop with `Run /github:create-issue-from-plan first` — the Issue is how we track progress.
 
-Check branch: `git branch --show-current`. If main, SlashCommand(/p:generate_branch).
+Read the plan without offset/limit, then read every file it references the same way, then check the Issue for existing checkbox state. Extract tasks phase-by-phase.
 
-### Plan Input
+## Interview checkpoint
 
-The `$ARGUMENTS` input contains both the plan reference (issue number or file path) and optional mode flags. Extract the intent:
-- Identify if `--swarm` flag is present (indicates user wants parallel team implementation)
-- Separate the flag from the plan reference itself
-- The plan reference is the remaining text after flag extraction
+Find and read the interview protocol:
+- `Glob(pattern: "**/sdlc/**/skills/interview/SKILL.md", path: "~/.claude/plugins")`
 
-Parse the plan reference:
-- Issue (`/implement #123` or `/implement #123 --swarm`): `gh issue view #123 --json body` → extract plan path → read
-- File (`/implement plans/file.md` or `/implement plans/file.md --swarm`): Read frontmatter for Issue. No Issue → error "Run `/github:create-issue-from-plan` first"
+Run it in context-only mode (no file updates, no Interview Insights section). Focus on task ordering, testing approach, code-style choices, and open decisions in the plan. The topic is the plan's goals and requirements.
 
-Read plan completely, check Issue for progress, read all referenced files (no limit/offset). Extract tasks from phases.
+## Routing
 
-### Interview Checkpoint
+Default is the standard flow: tasks run sequentially, one implementer at a time. `--swarm` switches to parallel teammates where the plan has independent tasks that don't touch the same files.
 
-Find and read the interview protocol using Glob:
-- Pattern: `**/sdlc/**/skills/interview/SKILL.md`
-- Search path: `~/.claude/plugins`
-
-Execute the interview protocol with these overrides:
-- Output to conversation context only — do not update files or write an Interview Insights section
-- Focus on: task ordering preferences, testing approach, code style choices, areas where the plan leaves decisions open
-- The topic for the interview is the plan's goals and requirements as parsed in the Plan Input step above
-
-### Mode Selection
-
-**If user requested swarm mode** (via `--swarm` flag): Execute the **Swarm Workflow** below.
-**Otherwise**: Execute the **Standard Workflow** below.
-
----
-
-## Standard Workflow
-
-The default implementation approach uses sequential subagent-driven development with review gates.
-
-### Subagent Workflow
-You orchestrate; implementer agents execute. Per task:
-
-1. **Dispatch implementer** (Task tool, `subagent_type: "implementer"`): task spec, TDD mode, context, files to reference. **When TDD mode is strict or soft**: Before dispatching, read TDD reference files via `Glob("**/tdd/references/*.md", path: "~/.claude/plugins")` and inject key excerpts into the implementer's Task prompt:
-   - From `mocking.md`: boundary-only rule, system boundary definition, legacy compatibility clause
-   - From `test-quality.md`: behavioral test criteria (WHAT not HOW, public interface, survives refactor)
-   - From `interface-design.md`: DI principle (accept dependencies, don't create them)
-   - Inject as literal text under a `TDD GUIDANCE:` section in the prompt. Do NOT include full files — extract the rules and one example each.
-2. **Handle questions**: Answer from plan/context first, else AskUserQuestion
-3. **Dispatch spec-reviewer** (`subagent_type: "spec-reviewer"`): original spec + implementation → verify nothing missing/extra, behavior matches
-4. **Dispatch code-quality-reviewer** (`subagent_type: "code-quality-reviewer"`): changed files → check bugs/smells/security/anti-patterns
-5. **Review loops**: Max 3 iterations. FAIL → re-dispatch implementer → re-review. After 3, escalate
-6. **Mark complete**: Update todo list after both reviews pass
-
-Trivial tasks (single-line): skip subagents, implement directly.
-
-### Progress Tracking
-Create todo list: phases (high-level), tasks (nested). Mark in_progress (dispatch) → completed (reviews pass).
-
-After **phase**: `gh issue edit #123 --body "..."` to update checkboxes. Plan immutable; Issue tracks progress.
-
----
-
-## Swarm Workflow
-
-An alternative approach using agent teams for implementation that parallelizes independent tasks while preserving review gates. This works well when the plan has multiple independent tasks that don't touch the same files.
-
-### Pre-flight (Same as Standard)
-
-Pre-flight checks are identical to Standard Workflow:
-- Rename session: `/rename "Implement: #$ARGUMENTS"` or `/rename "Implement: {plan-name}"`
-- Check TDD Mode from CLAUDE.md (`tdd:` strict/soft/off)
-- Check branch: `git branch --show-current`. If main, SlashCommand(/p:generate_branch)
-- Parse plan reference and read plan completely
-- Check Issue for progress
-- Read all referenced files (no limit/offset)
-- Extract tasks from phases
-
-### Task Analysis and Clustering
-
-After extracting tasks from plan, analyze for parallelization:
-
-1. **Determine file overlap**: Use plan's "Files touched", "Relevant Files", or "Implementation Details" metadata to identify which files each task modifies
-2. **Estimate if missing**: If a task doesn't list files, examine the task description to estimate which files will be modified before spawning teammates
-3. **Identify independent clusters**: Tasks with no file overlap can run in parallel. Tasks that touch the same files must run sequentially.
-4. **Dependency analysis**: Check for explicit dependencies (e.g., "Task B depends on Task A's interface"). Dependent tasks must run sequentially.
-
-**Example**: If Task 1 touches `src/auth.ts` and Task 2 touches `src/profile.ts`, they can run in parallel. If Task 3 also touches `src/auth.ts`, it must run sequentially after Task 1.
-
-### Team Prerequisites and Fallback
-
-Attempt to create the agent team using `TeamCreate` with a unique timestamped name: `implement-{plan-kebab}-{YYYYMMDD-HHMMSS}` and description: "Implement: {plan name or issue #}".
-
-If team creation fails (tool unavailable or experimental features disabled), inform the user that swarm mode requires agent teams to be enabled (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in settings.json), then fall back to executing the Standard Workflow instead. The plan is already parsed and ready to use.
-
-### Shared Task List
-
-Create tasks via `TaskCreate` for all implementation tasks from the plan. Each task should include:
-- Task name/description from plan
-- Files to modify (from analysis above)
-- Status: `pending`, `in_progress`, `completed`
-- `blockedBy`: Array of task IDs if dependent on other tasks
-
-Tasks marked `blockedBy` will not be claimed until blocking tasks complete. Independent tasks can be claimed immediately.
-
-### Teammate Spawn Protocol
-
-Spawn one teammate per independent task (tasks with no file overlap and no dependencies). Use the `Task` tool with `team_name` parameter and `subagent_type: "general-purpose"`.
-
-Each teammate prompt MUST include as string literals (NOT references to conversation):
-
-**Required Context in Each Spawn Prompt**:
+If swarm mode is requested but `TeamCreate` isn't available:
 ```
+Swarm mode requires agent teams. Set CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in settings.json or environment.
+Falling back to standard workflow.
+```
+Then continue with the plan already parsed.
+
+---
+
+## Standard workflow
+
+Per task:
+
+1. **Dispatch implementer** (`Task` tool, `subagent_type: "implementer"`) with: task spec, TDD mode, plan context, files to reference. When `tdd` is `strict` or `soft`, also pass the TDD reference docs — `Glob("**/tdd/references/*.md", path: "~/.claude/plugins")` and include the full file paths in the dispatch prompt. The implementer is trusted to apply `mocking.md`, `test-quality.md`, and `interface-design.md`; don't pre-digest them into rule bullets.
+2. **Answer questions** from plan/context first; escalate to `AskUserQuestion` only when the plan truly doesn't answer.
+3. **Dispatch `spec-reviewer`**: original spec + implementation → verify nothing missing, nothing extra, behavior matches.
+4. **Dispatch `code-quality-reviewer`**: changed files → bugs, smells, security, anti-patterns.
+5. **Review loop**: up to 3 iterations. On FAIL, re-dispatch the implementer with the review notes, then re-review. After 3 rounds without convergence, escalate to the user with the last issues and three options (try once more / skip / stop).
+6. **Mark complete** in the todo list after both reviews pass.
+
+Trivial single-line tasks: implement directly, skip the subagents.
+
+Track progress as: phases (high-level) with tasks nested under them. Flip each task `pending` → `in_progress` on dispatch and `in_progress` → `completed` after reviews pass. At the end of every *phase*, sync checkboxes to GitHub via `gh issue edit #123 --body "..."` — the plan is immutable, the Issue carries progress.
+
+---
+
+## Swarm workflow
+
+Parallelizes independent tasks while preserving the same review gates.
+
+### Task clustering
+
+After extracting tasks from the plan:
+
+- Pull `Files touched` / `Relevant Files` / `Implementation Details` metadata from the plan. Where missing, estimate from the task description before spawning.
+- Tasks that touch disjoint files can run in parallel. Tasks with any file overlap must serialize.
+- Honor explicit dependencies (`Task B depends on Task A's interface`) — those serialize too.
+
+Example: Task 1 touches `src/auth.ts`, Task 2 touches `src/profile.ts` → parallel. Task 3 also touches `src/auth.ts` → serializes after Task 1.
+
+### Team setup
+
+Create the team with `TeamCreate`: name `implement-{plan-kebab}-{YYYYMMDD-HHMMSS}`, description `Implement: {plan name or issue #}`. Populate the shared task list via `TaskCreate`, including `blockedBy` for dependent tasks (they won't be claimed until blockers finish).
+
+### Teammate dispatch
+
+Spawn one teammate per independent task via `Task` with `team_name` and `subagent_type: "general-purpose"`. The spawn prompt is self-contained — conversation context isn't visible to teammates, so embed everything as literal text.
+
+<example name="Teammate spawn prompt">
 You are implementing one task as part of an implementation team.
 
 TASK SPEC:
 {literal copy of task description from plan, including acceptance criteria}
 
 TDD MODE: {strict|soft|off}
-{If strict: "You MUST have a test before implementing. Follow Red-Green-Refactor."}
-{If soft: "Warn if no test exists, but proceed with implementation."}
+{If strict: "Write the test before the implementation. Follow Red-Green-Refactor."}
+{If soft: "If no test exists, warn and proceed."}
 {If off: "No test requirement."}
 
 FILES TO MODIFY:
-{list of files this task touches, from plan or estimation}
+{list of files this task touches}
 
 RELEVANT FILE CONTENTS:
-{read and include current contents of files to modify, plus any interfaces/types they depend on}
+{current contents of files to modify plus interfaces/types they depend on}
 
-DEPENDENCIES/INTERFACES:
-{any shared APIs, types, or contracts discovered by other teammates or from plan}
+DEPENDENCIES / INTERFACES:
+{any shared APIs, types, or contracts discovered by other teammates or from the plan}
 
-YOUR CONSTRAINTS:
-- Edit only your assigned files — the lead coordinates commits and reviews to maintain atomic task boundaries. Editing other files would create merge conflicts with concurrent teammates.
-- Don't run git, build, or test commands — other teammates are editing concurrently, and these operations would cause conflicts or interference.
-- If blocked or uncertain, send "BLOCKED: {reason}" via SendMessage — the lead has full plan context and can answer or escalate to the user.
-- Read files completely without limit/offset so you have full context for accurate implementation.
-- If you discover file overlap at runtime that wasn't detected during analysis, signal lead immediately via SendMessage.
+Constraints:
+- Edit only your assigned files. The lead coordinates commits and reviews; editing outside your scope creates conflicts with concurrent teammates.
+- Don't run git, build, or test commands — teammates are editing concurrently and those operations would interfere.
+- Read files completely (no limit/offset).
+- If blocked, send `BLOCKED: {reason}` via `SendMessage` — the lead has full plan context and can answer or escalate.
+- If you discover file overlap at runtime (a `SendMessage` from another teammate or a conflict), send `FILE OVERLAP DETECTED: {file path}. My task touches this file but {other teammate's task} also modifies it. Lead should serialize these tasks.`
+- When you create or modify a public API, interface, or type another teammate might depend on, send `INTERFACE UPDATE: {description with file:line}. May affect other tasks.`
 
-RUNTIME FILE OVERLAP DETECTION:
-If you discover that a file you need to modify is being touched by another teammate (indicated by SendMessage from that teammate or conflicts), send:
-"FILE OVERLAP DETECTED: {file path}. My task touches this file but {other teammate's task} also modifies it. Lead should serialize these tasks."
+When implementation is complete, self-review these dimensions before signaling:
+- Spec compliance — every requirement met?
+- Scope discipline — any code not explicitly specified? Extra surface = untested surface.
+- Basic health — compiles / runs without errors?
+- Test validity (if TDD) — does the test pass?
+- Clarity — obvious bugs or typos?
 
-API/INTERFACE SHARING:
-When you create or modify a public API, interface, or type that other teammates might depend on, share immediately via SendMessage:
-"INTERFACE UPDATE: {description of API/type change with file:line reference}. This may affect other tasks."
+If self-review fails, fix and re-review. When all checks pass, send `TASK COMPLETE: {task name}` via `SendMessage` and wait for `shutdown_request` from the lead.
+</example>
 
-COMPLETION PROTOCOL:
-When implementation is complete:
-1. Self-review across these dimensions (this is CRITICAL):
-   - **Spec compliance**: Does implementation match every requirement in task spec?
-   - **Scope discipline**: Is there ANY code not explicitly specified? Extra code = untested surface area.
-   - **Basic health**: Does it compile/run without errors?
-   - **Test validity** (if TDD mode): Does the test pass? If it fails, implementation is incomplete.
-   - **Clarity**: Are there obvious bugs or typos?
+### Lead orchestration
 
-2. If self-review fails: Fix issues and re-review. Do NOT signal completion until all checks pass.
+You run the team:
 
-3. When all checks pass:
-   - Send "TASK COMPLETE: {task name}" via SendMessage
-   - Wait for shutdown_request from lead
+- **Launch independents in parallel.** Track which teammate owns which task.
+- **File-overlap escalation.** On `FILE OVERLAP DETECTED`, send `shutdown_request` to the newer teammate, wait for the earlier task to finish, then respawn the shut-down task.
+- **Interface broadcast.** On `INTERFACE UPDATE`, forward via `SendMessage` to teammates whose tasks plausibly depend on the API.
+- **Questions.** Answer `BLOCKED` messages from plan/context, or escalate via `AskUserQuestion` and relay back.
+- **Per-task commit + review.** When a teammate signals `TASK COMPLETE`:
+  1. Sanity-check their changes (compiles, no obvious typos).
+  2. Stage only the files they modified: `git add {files}`.
+  3. Atomic conventional commit:
+     ```bash
+     git commit -m "$(cat <<'EOF'
+     feat: {task description}
 
-If blocked or uncertain, send "BLOCKED: {reason}" via SendMessage. Lead will answer from plan/context or escalate to user.
-```
+     Implements task from {plan reference}
+     EOF
+     )"
+     ```
+  4. Dispatch `spec-reviewer` and `code-quality-reviewer` with the same 3-iteration loop as the standard workflow.
+  5. On both-pass: `TaskUpdate` the shared task list, `gh issue edit` the checkbox.
+- **Unblock dependents.** After a task completes reviews, scan the task list for items that were `blockedBy` it. Spawn teammates for any now-ready task.
 
-### Lead Orchestration
+Teammate timeout is 10 minutes per teammate from spawn. On timeout, send `shutdown_request`, proceed with whatever's done, and note the timeout in the final output. If a teammate gets stuck (repeated identical messages, no progress), pick: handle it yourself via the standard flow, respawn with tighter scope, or escalate — choose on criticality.
 
-As team lead, you coordinate teammates and handle commits + review gates:
+### Cleanup invariant
 
-**Spawn independent tasks in parallel**: Launch teammates for all tasks that can run concurrently (no file overlap, no dependencies). Track which teammates are working on which tasks.
+**The team must be deleted before the command returns, regardless of whether tasks succeeded, failed, or timed out.** Skipping leaks team slots and orphans the shared task list.
 
-**Handle runtime file overlap**: If a teammate signals "FILE OVERLAP DETECTED", immediately serialize those tasks. Send shutdown_request to the newer teammate, wait for it to complete, then re-spawn it after the earlier task completes.
+1. `SendMessage` with `type: "shutdown_request"` to each teammate.
+2. Wait briefly for shutdown confirmations.
+3. `TeamDelete`.
 
-**Handle API/interface updates**: When a teammate shares "INTERFACE UPDATE", broadcast to other relevant teammates via SendMessage so they can incorporate the change.
-
-**Answer questions**: When a teammate sends "BLOCKED", answer from plan/context if possible. If not, use AskUserQuestion to escalate to user, then relay answer to teammate.
-
-**Stage and commit per task**: When a teammate signals "TASK COMPLETE":
-1. Review their changed files for basic sanity (compiles, no obvious typos)
-2. Stage the files they modified: `git add {specific files}`
-3. Create atomic commit using conventional commit format:
-   ```bash
-   git commit -m "$(cat <<'EOF'
-   feat: {task description}
-
-   Implements task from {plan reference}
-   EOF
-   )"
-   ```
-4. Proceed to review gates (below)
-
-**Review gates per task** (preserving existing two-stage review):
-1. **Dispatch spec-reviewer** (`subagent_type: "spec-reviewer"`): original task spec + implementation → verify nothing missing/extra, behavior matches
-2. **Dispatch code-quality-reviewer** (`subagent_type: "code-quality-reviewer"`): changed files → check bugs/smells/security/anti-patterns
-3. **Review loops**: Max 3 iterations. If FAIL → re-dispatch implementer teammate with fixes → re-review. After 3 iterations, escalate to user.
-4. **Mark complete**: After both reviews pass, update shared task list via TaskUpdate, update Issue checkboxes via `gh issue edit`
-
-**Launch dependent tasks**: When a blocking task completes (passes reviews), check the task list for tasks that were `blockedBy` the completed task. If all blocking tasks are done, spawn a new teammate for the newly-unblocked task.
-
-### Progress Tracking
-
-Maintain the same todo list structure as Standard Workflow: phases (high-level), tasks (nested). Mark:
-- `pending` → `in_progress` (teammate spawned)
-- `in_progress` → `completed` (reviews pass)
-
-After **phase** completes: `gh issue edit #123 --body "..."` to update checkboxes. Plan immutable; Issue tracks progress.
-
-Display periodic status updates showing which tasks are in progress, which are blocked, and which are complete.
-
-### Completion Protocol
-
-Wait for all teammates to signal completion by sending "TASK COMPLETE" messages. Timeout: 10 minutes per teammate from spawn time.
-
-**If timeout occurs**: Send shutdown_request to timed-out teammate, proceed with available work, note timeout in final output.
-
-**Fallback behavior**: If a teammate fails or gets stuck (repeated similar messages, no progress), you have three options:
-1. Note the failure, send shutdown_request, and handle that task yourself using Standard Workflow subagent approach
-2. Spawn a replacement teammate with clearer scoped instructions
-3. Escalate to user if critical
-
-Choose based on how critical that task is and whether the blockage is resolvable.
-
-### Resource Cleanup
-
-After all tasks complete (or timeout), always clean up team resources:
-
-Send shutdown requests to all teammates via `SendMessage` with `type: "shutdown_request"`, wait briefly for confirmations, then call `TeamDelete` to remove the team and its task list.
-
-If cleanup itself fails, inform the user: "Team cleanup incomplete. You may need to check for lingering team resources."
-
-Execute cleanup regardless of outcome—even if earlier steps errored or teammates timed out, cleanup must run before ending.
+If cleanup itself errors, tell the user `"Team cleanup incomplete. You may need to check for lingering team resources."` and continue to the Output section — the user still gets the summary.
 
 ---
 
 ## Output
 
-### Per Phase
-Verify tasks complete, update Issue checkboxes, status update. Continue if multiple phases, else pause.
+**Per phase:** verify all tasks in the phase passed reviews, update Issue checkboxes, print a status update. Continue to the next phase automatically; if it was the final phase, pause for the wrap-up below.
 
-### Final
-- Summary (bullets)
-- Review iterations if any
-- `git diff --stat`
-- "Run `/review` for thorough analysis"
+**Final wrap-up:**
+- Summary (bullets).
+- Review iterations used, if any.
+- `git diff --stat`.
+- `"Run /review for thorough analysis"`.
 
-**Change walkthrough**: Find and read the walkthrough skill:
-- Pattern: `**/sdlc/**/skills/agent-change-walkthrough/SKILL.md`
-- Search path: `~/.claude/plugins`
+**Change walkthrough.** Find and run the walkthrough skill:
+- `Glob(pattern: "**/sdlc/**/skills/agent-change-walkthrough/SKILL.md", path: "~/.claude/plugins")`
 
-Execute the walkthrough protocol across all tasks completed in this session. The topic is the full set of changes made: use `git diff HEAD~{n}` where `n` is the number of commits made this session (or `git diff {base-branch}...HEAD` if branch tracking is available).
+Run it across every task completed in this session. The topic is the full diff: `git diff HEAD~{n}` where `n` is the number of commits made this session (or `git diff {base-branch}...HEAD` where tracking is available).
 
-**De-slop gate**: Run a lightweight check for AI artifacts introduced during implementation:
+**De-slop gate** — non-blocking:
+1. `uvx desloppify scan --path .` — capture the strict score.
+2. Include the score in the summary.
+3. If issues found, summarize briefly and ask `"Fix slop now or later?"`:
+   - **Now** — invoke the de-slop skill's iterative fix loop (`uvx desloppify next` → fix → repeat until clean), then re-scan to confirm the score improved.
+   - **Later** — note it in the summary and end.
+4. If `desloppify` isn't installed (command fails), skip silently.
 
-1. `uvx desloppify scan --path .` — capture the strict score
-2. Report the score in the summary
-3. If issues found, present a brief summary and ask: "Fix slop now or later?"
-   - "Now": invoke the de-slop skill's iterative fix loop (`uvx desloppify next` → fix → repeat until clean), then re-scan to confirm score improved
-   - "Later": record a note in the summary and end session
-4. If `desloppify` is unavailable (command fails), skip this step silently
+**Swarm mode additions.** When `--swarm` was used, also report:
+- Tasks parallelized vs serialized.
+- Runtime file-overlap escalations resolved.
+- Teammate timeout / failure counts.
+- Wall-clock time vs estimated sequential time (if measurable).
 
-This gate is non-blocking — it never prevents session completion.
+## Error handling
 
-**Swarm mode additions**: When `--swarm` was used, include:
-- Number of tasks parallelized vs serialized
-- Any runtime file overlaps detected and resolved
-- Teammate timeout/failure counts if any
-- Total wall-clock time vs estimated sequential time (if measurable)
-
-## Error Handling
-
-**Stuck**: Answer from context or report blockage.
-
-**Review loop not converging** (3 fails): Report last issues, offer options (try once more / skip / stop).
-
-**Spec mismatch**: Report expected vs found vs why, then stop.
+- **Teammate stuck.** Answer from context or report the blockage to the user.
+- **Review loop won't converge after 3 rounds.** Report the last issues and offer: try once more / skip / stop.
+- **Spec mismatch.** Report expected vs found vs why, then stop.
 
 ## Plan
+
 $ARGUMENTS

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -1,139 +1,94 @@
 # Create Implementation Plan
 
-## Session Naming
+## Role
 
-Before starting, rename this session for clarity:
-- If `$ARGUMENTS` provided: `/rename "Plan: $ARGUMENTS"`
-- Otherwise infer from context: `/rename "Plan: {feature-name}"`
+Produce a comprehensive PRD in `plans/*.md` that resolves the given task. The plan is thorough enough to fix the root cause and prevent regressions, while staying surgical — only the minimal changes necessary to address the task.
 
 ## Priorities
 
 Completeness (root cause addressed) > Minimality (surgical changes) > Clarity (readable plan)
 
-## Goal
+## Session setup
 
-Create a comprehensive PRD in `plans/*.md` that resolves the given task. The plan must be thorough enough to fix the root cause and prevent regressions, while containing only the minimal changes necessary to address the task.
-
-## Constraints
-
-**Research codebase first (start with README.md, then relevant files)**
-Plans based on assumptions rather than actual code state lead to mismatched implementations.
-
-**Interview the user before planning**
-Upfront interviews are cheaper than replanning after implementation starts.
-
-**Fill every section of the PRD template completely**
-Incomplete plans cause implementation ambiguity and require mid-task clarifications that break flow.
-
-**Split phases with complexity >5 into sub-tasks (max 5 tasks per phase)**
-Agent context windows can't reliably hold large tasks without dropping requirements or losing track of dependencies.
-
-**No decorators - keep implementation simple**
-Decorators add abstraction complexity that conflicts with the "Minimality" priority.
-
-**Report new library needs in the Notes section**
-New dependencies need human approval for security audits, maintenance burden assessment, licensing compatibility checks, and bundle size impact review.
-
-**Run multi-LLM blindspot review after draft**
-Different models have different blind spots - Codex catches API misuse, Gemini catches architectural inconsistencies.
-
-**Update frontmatter after review, then commit and create issue**
-Marking `reviewed: true` signals the plan is ready for implementation.
-
-## Plan Format
-
-Find and read the PRD template using Glob:
-- Pattern: `**/sdlc/**/references/prd-template.md`
-- Search path: `~/.claude/plugins`
-
-Fill every section completely. Save to `plans/<descriptive-name>.md`.
-
-The template includes:
-- Frontmatter with metadata (title, type, issue, status, reviewed, reviewers, created)
-- ## Metadata (type, priority, severity, complexity, status)
-- ## Overview (problem statement, goals, success metrics)
-- ## User Stories
-- ## Requirements (functional, non-functional, technical)
-- ## Scope (in scope, out of scope, future considerations)
-- ## Impact Analysis (affected areas, users, system impact, dependencies, breaking changes)
-- ## Steps to Reproduce (for bugs)
-- ## Root Cause Analysis (for bugs)
-- ## Solution Design (approach, alternatives, data/API/UI changes)
-- ## Implementation Plan (Phase 1-5 with **Complexity**: <1-10> | **Priority**: <High|Medium|Low>)
-- ## Relevant Files (existing, new, test files)
-- ## Testing Strategy (unit, integration, E2E, manual)
-- ## Risk Assessment (technical/business risks, mitigation)
-- ## Rollback Strategy (steps, conditions)
-- ## Validation Commands (bash commands to verify success)
-- ## Acceptance Criteria
-- ## Dependencies (new/updated packages)
-- ## Notes & Context (additional context, assumptions, constraints, related tasks, references, open questions)
-- ## Blindspot Review (reviewers, date, addressed/deferred/dismissed concerns)
-
-## Multi-LLM Blindspot Review
-
-Find and read the blindspot review protocol:
-- Pattern: `**/sdlc/**/references/blindspot-review-protocol.md`
-- Search path: `~/.claude/plugins`
-
-This protocol defines:
-- How to run Codex and Gemini plan critics in parallel
-- Review consolidation process (deduplicate, flag consensus, sort by severity)
-- Plan refinement rules (when to address/defer/dismiss concerns)
-- How to document review findings in the plan
-
-## References
-
-Load these files before proceeding (use Glob with path `~/.claude/plugins`):
-- `**/sdlc/**/references/prd-template.md` - Full PRD template with all sections
-- `**/sdlc/**/references/blindspot-review-protocol.md` - Multi-LLM review protocol
+`/rename "Plan: $ARGUMENTS"` — or infer a feature name from context and use that.
 
 ## Workflow
 
-**Scope Challenge Checkpoint** _(mandatory, never skip)_
-Before interviewing or researching, answer these questions from codebase context:
+The flow is five checkpoints. Each exists because skipping it reliably produces worse plans: scope challenge stops duplicate work, interview surfaces ambiguity before it becomes rework, codebase research prevents designs that ignore what already exists, multi-LLM review catches blind spots one model misses, finalization creates the paper trail that lets implementation start.
+
+### 1. Scope challenge
+
+Before interviewing or researching, answer from codebase context:
 1. What does existing code already handle that overlaps with this request?
 2. What is the minimum file/class footprint to satisfy the goal?
 3. Flag if estimated scope exceeds 8 files or 2 new abstractions (smell, not a block — but document it).
 
-Based on findings, choose one path:
-- **SCOPE REDUCTION** — Existing code already solves this or the ask can be reframed to a smaller change. Stop and present a reduced proposal to the user before proceeding.
-- **PROCEED** — Scope is justified. Continue to Interview.
+Based on findings, pick:
+- **Scope reduction** — existing code already solves this, or the ask can be reframed to a smaller change. Stop and present a reduced proposal to the user before proceeding.
+- **Proceed** — scope is justified. Continue to the interview.
 
 Document the scope decision (what exists, what's new, why the chosen path) in the Notes & Context section of the plan.
 
-**Interview Checkpoint**
-Find and read the interview protocol using Glob:
-- Pattern: `**/sdlc/**/skills/interview/SKILL.md`
-- Search path: `~/.claude/plugins`
+### 2. Interview
 
-Execute the interview protocol with these overrides:
-- Output to conversation context only — do not update files or write an Interview Insights section
-- Focus on: architecture approaches, scope boundaries, technology choices, user intent, priority tradeoffs
-- The topic for the interview is: the user's task as provided in $ARGUMENTS
+Find and read the interview protocol:
+- `Glob(pattern: "**/sdlc/**/skills/interview/SKILL.md", path: "~/.claude/plugins")`
 
-**Research Checkpoint**
-Read README.md to understand architecture patterns and conventions, then explore relevant codebase files to map existing abstractions and integration points. Plans grounded in actual code state avoid mismatched implementations.
+Run it in context-only mode (no file updates, no Interview Insights section). Focus on architecture approaches, scope boundaries, technology choices, user intent, priority tradeoffs. Topic is the user's task from `$ARGUMENTS`.
 
-Spawn `web-search-researcher` subagent in parallel with codebase exploration to research best practices, alternatives, and current documentation relevant to the task. The web-search-researcher must complete or timeout (3 minutes) before the Solution Design and Alternatives Considered sections are authored, to ensure web findings are available. If web search fails or returns no results, proceed with codebase-only findings.
+Upfront interviews are much cheaper than replanning after implementation starts.
 
-After exploration completes, produce a **"What Already Exists"** summary before authoring the Solution Design:
-- List existing abstractions, utilities, or patterns that partially or fully address the task
-- For each: note whether to REUSE, EXTEND, or REPLACE, with one-line justification
-- This prevents designing solutions that duplicate or conflict with existing code
+### 3. Research
 
-**Draft Plan Checkpoint**
-Load the PRD template and fill every section completely. Save to `plans/<name>.md`.
+Read `README.md` to understand architecture patterns and conventions, then explore relevant codebase files to map existing abstractions and integration points. Plans grounded in actual code state avoid mismatched implementations.
 
-For each new codepath in the Implementation Plan, add one sentence to the Risk Assessment covering: what fails, how it manifests, and the fallback. Format: `[Codepath] — fails when [condition]; manifests as [symptom]; fallback: [recovery]`.
+Spawn `web-search-researcher` as a parallel subagent to gather best practices, alternatives, and current documentation. Give it up to 3 minutes — the Solution Design and Alternatives Considered sections should be authored with its findings available. If it fails or returns nothing, proceed with codebase-only findings.
 
-**Blindspot Review Checkpoint**
-Load the blindspot review protocol, then run Codex and Gemini critics in parallel. Consolidate their feedback (deduplicate, flag consensus issues, sort by severity), then refine the plan by addressing, deferring, or dismissing each concern with justification.
+After exploration, produce a **"What Already Exists"** summary before authoring the Solution Design:
+- List existing abstractions, utilities, or patterns that partially or fully address the task.
+- For each: REUSE, EXTEND, or REPLACE, with a one-line justification.
 
-**Finalization Checkpoint**
-Update frontmatter to mark `reviewed: true`, add `reviewers: ["codex", "gemini"]`, and set `status: Ready for Implementation`. Commit to branch `plan/feature-name` to create an audit trail, then run `/github:create-issue-from-plan plans/<name>.md` to make the work trackable.
+This prevents designing solutions that duplicate or conflict with existing code.
 
-Append deferred items from the plan's "Out of Scope / Future Considerations" section to `TODOS.md` in the project root (create if absent). Each entry format:
+### 4. Draft plan
+
+Load the PRD template:
+- `Glob(pattern: "**/sdlc/**/references/prd-template.md", path: "~/.claude/plugins")`
+
+Fill every section — incomplete plans force implementers to ask mid-task, which breaks flow. Save to `plans/<descriptive-name>.md`.
+
+Template sections (abbreviated):
+- Frontmatter — title, type, issue, status, reviewed, reviewers, created
+- Metadata, Overview, User Stories
+- Requirements (functional, non-functional, technical)
+- Scope (in / out / future)
+- Impact Analysis (affected areas, users, dependencies, breaking changes)
+- Steps to Reproduce + Root Cause Analysis (for bugs)
+- Solution Design (approach, alternatives, data/API/UI changes)
+- Implementation Plan — Phase 1–5, each with `Complexity: <1-10> | Priority: <High|Medium|Low>`
+- Relevant Files, Testing Strategy
+- Risk Assessment, Rollback Strategy, Validation Commands, Acceptance Criteria
+- Dependencies, Notes & Context
+- Blindspot Review (filled in step 5)
+
+Keep phases at ≤5 tasks each; split anything with complexity >5 into sub-tasks. Agent context windows don't reliably hold large tasks without dropping requirements.
+
+For each new codepath in the Implementation Plan, add one sentence to Risk Assessment: `[Codepath] — fails when [condition]; manifests as [symptom]; fallback: [recovery]`.
+
+Keep implementation simple — no decorators, no speculative abstractions. New library needs go in Notes & Context so humans can weigh security, maintenance, licensing, and bundle impact before approving.
+
+### 5. Blindspot review
+
+Load the blindspot protocol:
+- `Glob(pattern: "**/sdlc/**/references/blindspot-review-protocol.md", path: "~/.claude/plugins")`
+
+Run Codex and Gemini plan critics in parallel per the protocol. They catch different things — Codex tends to flag API misuse, Gemini tends to flag architectural inconsistencies. Consolidate their feedback (deduplicate, flag consensus issues, sort by severity), then refine the plan by addressing, deferring, or dismissing each concern with justification. Document the review in the plan's Blindspot Review section.
+
+### 6. Finalization
+
+Update frontmatter: `reviewed: true`, `reviewers: ["codex", "gemini"]`, `status: Ready for Implementation`. Commit on branch `plan/feature-name` for audit trail, then `/github:create-issue-from-plan plans/<name>.md` to make the work trackable.
+
+Append deferred items from the plan's "Out of Scope / Future Considerations" to `TODOS.md` in the project root (create if absent). Each entry:
 ```
 ## <item-title>
 Why: <why it matters>
@@ -147,5 +102,5 @@ $ARGUMENTS
 
 ## Report
 
-- Summarize work done in concise bullet points
-- Include absolute path to the plan created in `plans/*.md`
+- Work done, concise bullets.
+- Absolute path to the plan in `plans/*.md`.

--- a/commands/research-deep.md
+++ b/commands/research-deep.md
@@ -1,199 +1,96 @@
 # Multi-LLM Deep Research
 
-## Session Naming
+## Role
 
-Before starting, rename this session:
-- If `$ARGUMENTS` provided: `/rename "Deep Research: $ARGUMENTS"`
-- Otherwise wait for topic, then `/rename "Deep Research: {topic}"`
+You orchestrate a four-phase research pipeline (Discovery → Independent Analysis → Cross-Pollination Refinement → Synthesis) over a codebase topic, coordinating Claude, Gemini, and Codex. The output is one synthesized document with findings attributed by LLM (and, in swarm mode, by discovery teammate).
 
 ## Priorities
 
 Depth (multi-perspective) > Accuracy (consensus validation) > Concision
 
-## Goal
+## Session setup
 
-Execute 4-phase multi-LLM research (Discovery → Independent Analysis → Cross-Pollination Refinement → Synthesis) on a codebase topic, producing a comprehensive document with LLM attribution markers showing which findings came from Claude, Gemini, and/or Codex.
+Rename the session up front: `/rename "Deep Research: $ARGUMENTS"` — or, if no topic was supplied, ask for one and then rename.
 
-## CRITICAL: Parse Flags and Route
+## Routing
 
-BEFORE doing anything else, parse `$ARGUMENTS` for flags:
-1. Check if `--swarm` appears as a standalone token (not inside quotes)
-2. If found: set `SWARM_MODE=true`, remove all `--swarm` tokens from the argument string
-3. The remaining text (trimmed) is the research topic
-4. If the topic is empty after removing `--swarm`: prompt the user "Please provide a research question." and stop
+The default mode is `--no-swarm` equivalent: one Claude discovery subagent. Pass `--swarm` to use an agent team for discovery (Locator + Analyzer + Pattern Finder sharing findings in real time via `SendMessage`). Strip `--swarm` from the arg string and treat what remains as the topic. If the topic is empty after stripping, ask the user for a research question.
 
-## Constraints
-
-### Phase 1: Discovery
-
-If `SWARM_MODE=true`: skip directly to **Swarm Discovery** below. Do NOT execute Standard Discovery.
-If `SWARM_MODE` is not set: skip directly to **Standard Discovery** below. Do NOT execute Swarm Discovery.
-
-#### Swarm Discovery (Agent Team)
-
-**IMPORTANT: Steps 6 and 7 below are mandatory. If any step before Step 7 fails (including Step 6), you MUST still execute Step 7 (Cleanup Team) before proceeding to Phase 2 or reporting the error.**
-
-##### Step 1: Create Team (validates prerequisites)
-
-Create the agent team with a unique timestamped name. This also validates that agent teams are available:
-- Team name: `research-deep-{topic-kebab}-{YYYYMMDD-HHMMSS}` (e.g., `research-deep-auth-flow-20260207-143052`)
-- Call `TeamCreate` with this name and description: "Deep Research Discovery: {topic}"
-- **If TeamCreate fails or the tool is unavailable**: Output this error message and execute the Standard Discovery workflow instead (topic is already parsed with `--swarm` removed):
-  ```
-  Swarm mode requires agent teams. Set CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in settings.json or environment.
-  Falling back to standard discovery mode.
-  ```
-
-##### Step 2: Create Working Directory
-
-- Create `research/.deep-research-$(date +%Y%m%d-%H%M%S)/`
-- Read any user-mentioned files FULLY (no limit/offset) before spawning teammates
-
-##### Step 3: Create Research Tasks
-
-Use `TaskCreate` to create tasks for the shared task list:
-1. **Locate relevant files** — Find all files, directories, and components related to the research topic
-2. **Analyze implementation details** — Trace data flow, understand how components interact, document with file:line refs
-3. **Find patterns and conventions** — Identify reusable patterns, similar implementations, and coding conventions
-
-##### Step 4: Spawn Teammates
-
-Spawn 3 teammates via the `Task` tool with `team_name` parameter and `subagent_type: "general-purpose"`:
-
-**Teammate 1: Locator**
+If swarm mode is requested but `TeamCreate` fails or the tool is unavailable, tell the user:
 ```
-You are a codebase locator on a deep research team investigating: "{topic}"
-
-Your role: Find ALL files, directories, and components relevant to this topic.
-
-Instructions:
-1. Check TaskList for your assigned task
-2. Use Glob and Grep to search with multiple naming patterns and extensions
-3. Categorize findings: Implementation Files, Test Files, Configuration, Type Definitions, Documentation
-4. Include directory counts ("Contains X files")
-5. Share important discoveries with teammates via SendMessage — especially if you find files that the Analyzer or Pattern Finder should examine
-6. When done, update your task via TaskUpdate (mark completed)
-7. Send a message to the team lead: "RESEARCH COMPLETE"
-
-Do NOT read file contents in depth — focus on locating and categorizing.
-All findings must include full file paths.
+Swarm mode requires agent teams. Set CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in settings.json or environment.
+Falling back to standard discovery mode.
 ```
+Then continue with the standard workflow — the topic is already parsed.
 
-**Teammate 2: Analyzer**
-```
-You are a codebase analyzer on a deep research team investigating: "{topic}"
+## Phase 1 — Discovery
 
-Your role: Analyze implementation details, trace data flow, and document how components interact.
+Create `research/.deep-research-$(date +%Y%m%d-%H%M%S)/` and read any user-mentioned files fully (no limit/offset) before spawning.
 
-Instructions:
-1. Check TaskList for your assigned task
-2. Read files thoroughly before making statements
-3. Trace actual code paths — don't assume
-4. Include file:line references for ALL claims
-5. Focus on "how" it works: entry points, core logic, data flow, error handling
-6. Share important discoveries with teammates via SendMessage — especially patterns you notice (for Pattern Finder) or files that need locating (for Locator)
-7. When done, update your task via TaskUpdate (mark completed)
-8. Send a message to the team lead: "RESEARCH COMPLETE"
+**Standard discovery** spawns one general-purpose subagent that runs `codebase-locator`, `codebase-analyzer`, and `codebase-pattern-finder` in sequence, plus a parallel `web-search-researcher` subagent. Output goes to `context.md`.
 
-Document: Entry Points, Core Implementation, Data Flow, Key Patterns, Configuration, Error Handling.
-```
+**Swarm discovery** creates an agent team named `research-deep-{topic-kebab}-{YYYYMMDD-HHMMSS}` and registers three shared tasks via `TaskCreate`:
+- Locate relevant files
+- Analyze implementation details
+- Find patterns and conventions
 
-**Teammate 3: Pattern Finder**
-```
-You are a codebase pattern finder on a deep research team investigating: "{topic}"
+Spawn three `general-purpose` teammates via `Task` with the `team_name` parameter. Each uses `SendMessage` to share discoveries in real time. In parallel, spawn `web-search-researcher` as a plain subagent (no `team_name`) — web findings supplement but never block.
 
-Your role: Find similar implementations, usage examples, and existing patterns that illuminate the topic.
+Wait for all three teammates to send `RESEARCH COMPLETE`. Cap each at 10 minutes wall clock. Web research gets up to 2 extra minutes after teammates finish, then proceeds without it.
 
-Instructions:
-1. Check TaskList for your assigned task
-2. Show working code examples, not just snippets
-3. Include file:line references for all code examples
-4. Show multiple variations when they exist
-5. Categorize: API patterns, Data patterns, Component patterns, Testing patterns
-6. Share important discoveries with teammates via SendMessage — especially if you find patterns the Analyzer should trace or files the Locator missed
-7. When done, update your task via TaskUpdate (mark completed)
-8. Send a message to the team lead: "RESEARCH COMPLETE"
+### Teammate briefs (swarm mode)
 
-Include test patterns alongside implementation patterns where they exist.
-```
+<example name="Locator">
+You are the codebase locator on a deep-research team investigating "{topic}". Check `TaskList` for your assigned task. Find all files, directories, and components relevant to the topic using Glob and Grep with multiple naming patterns and extensions. Categorize as Implementation / Test / Configuration / Types / Documentation, with directory counts. Share discoveries with the Analyzer and Pattern Finder via `SendMessage` — especially files they should examine. Don't read file contents in depth — locate and categorize. All findings include full file paths. Mark your task completed via `TaskUpdate` and send `RESEARCH COMPLETE` to the lead.
+</example>
 
-##### Step 4b: Web Research
+<example name="Analyzer">
+You are the codebase analyzer on a deep-research team investigating "{topic}". Check `TaskList` for your assigned task. Read files thoroughly; trace actual code paths rather than assuming. Every claim cites `file:line`. Focus on how it works: entry points, core logic, data flow, error handling. Share patterns with the Pattern Finder and missing files with the Locator via `SendMessage`. Document: Entry Points, Core Implementation, Data Flow, Key Patterns, Configuration, Error Handling. Mark your task completed and send `RESEARCH COMPLETE`.
+</example>
 
-Spawn `web-search-researcher` as a subagent (NOT a teammate) in parallel with the team. Use the Task tool WITHOUT the `team_name` parameter. Include its findings when writing `context.md` in Step 6 as a concise summary (max 500 words) to avoid exceeding Phase 2 LLM context budgets. If web search fails or returns no results, proceed with codebase-only findings.
+<example name="Pattern Finder">
+You are the codebase pattern finder on a deep-research team investigating "{topic}". Check `TaskList` for your assigned task. Show working code examples (not just snippets), with `file:line` references and multiple variations where they exist. Categorize as API / Data / Component / Testing patterns. Include test patterns alongside implementation. Share leads with the Analyzer and Locator via `SendMessage`. Mark your task completed and send `RESEARCH COMPLETE`.
+</example>
 
-##### Step 5: Wait for Completion
+### context.md
 
-Wait for all 3 teammates to send "RESEARCH COMPLETE" messages. Timeout: 10 minutes from when each teammate was spawned (so max 10 minutes wall clock, not 30 cumulative). Also wait for the web-search-researcher subagent spawned in Step 4b.
+Merge all teammate (or solo-agent) findings plus the web summary (capped ~500 words) into `context.md`, targeting under 50K characters for CLI compatibility. Preserve every `file:line` reference. In swarm mode, tag findings with `[Locator]`, `[Analyzer]`, `[Pattern Finder]`.
 
-- If all complete: proceed with all findings
-- If any teammate times out: proceed with available findings, note which teammates timed out
-- If web researcher is still running when teammates finish: wait up to 2 more minutes, then proceed without it. Web research is supplementary — it always runs but never blocks command completion.
+### Cleanup invariant (swarm mode)
 
-##### Step 6: Write context.md
+**The team must be deleted before Phase 2 starts, regardless of whether Phase 1 succeeded.** Skipping leaks team slots and orphans the shared task list.
 
-**CRITICAL: This step must complete BEFORE starting Phase 2.** Phase 2 LLMs read from `context.md`.
-
-Collect all teammate findings and write them to `context.md` in the working directory:
-- Merge findings from all teammates into a single discovery document
-- Target <50K characters for CLI compatibility (same as Standard Discovery)
-- Include team attribution: `[Locator]`, `[Analyzer]`, `[Pattern Finder]` alongside findings
-- All file:line references preserved
-
-##### Step 7: Cleanup Team
-
-**CRITICAL: Execute this step regardless of outcome. Whether Step 6 succeeded or failed — ALWAYS clean up before proceeding to Phase 2.**
-
-1. Send shutdown requests to all teammates via `SendMessage` with `type: "shutdown_request"`
+1. `SendMessage` with `type: "shutdown_request"` to each teammate
 2. Wait briefly for shutdown confirmations
-3. Call `TeamDelete` to remove the team and its task list
+3. `TeamDelete` to remove the team
 
-If cleanup itself fails, inform the user but continue to Phase 2: "Team cleanup incomplete. You may need to check for lingering team resources."
+If cleanup itself errors, tell the user `"Team cleanup incomplete. You may need to check for lingering team resources."` and continue — Phase 2 still runs.
 
-#### Standard Discovery (Claude only)
+## Phase 2 — Independent Analysis
 
-- Read any user-mentioned files first
-- Create `research/.deep-research-$(date +%Y%m%d-%H%M%S)/`
-- Spawn one discovery agent using codebase-locator, codebase-analyzer, and codebase-pattern-finder
-- Spawn `web-search-researcher` subagent in parallel with codebase discovery agents. If web search is still running when codebase discovery completes, wait up to 2 additional minutes before proceeding without it.
-- Target <50K characters for CLI compatibility
-- Merge web search findings into `context.md` as a concise summary (max 500 words) to avoid exceeding Phase 2 LLM context budgets. If web search fails or returns no results, proceed with codebase-only findings.
-- Save to `context.md`
+Three LLMs read `context.md` and produce independent analyses in parallel. This phase is identical in both modes.
 
----
-
-### Phase 2: Independent Analysis (3 LLMs in parallel)
-
-#### Model Resolution
-
-Before launching LLMs, load the model registry:
+Load the model registry first:
 - `Glob(pattern: "**/sdlc/**/config/model-registry.md", path: "~/.claude/plugins")` → Read result
-- Use `gemini-flagship` and `codex-flagship` from the registry in the commands below.
+- Use `gemini-flagship` and `codex-flagship` IDs from the registry.
 
-This phase is **unchanged** regardless of `--swarm` flag. It always reads from `context.md`.
+Each LLM's prompt includes:
+- **Breadth first, depth second** — identify all subtopics before deep-diving.
+- **Use web search extensively — don't rely solely on training data.**
+- **Iterate until genuinely done, then append `<!-- RESEARCH_COMPLETE -->` as a completion signal.**
+- **On each continuation, name the gap you're closing before adding content.**
 
-Each LLM gets `context.md` embedded in its prompt plus enhanced instructions for independent, thorough research.
+### Invocations (all three launched simultaneously)
 
-#### Analysis Prompt Guidelines
+- **Claude**: `Task` agent, `subagent_type: "general-purpose"`, `max_turns: 50`. Prompt ends with the `RESEARCH_COMPLETE` signal instruction.
+- **Gemini**: `timeout 600 gemini -m <gemini-flagship> --approval-mode yolo`, prompt piped to stdin via Bash (background).
+- **Codex**: `echo "<prompt>" | codex exec --skip-git-repo-check -m <codex-flagship> --reasoning-effort xhigh --full-auto 2>/dev/null` via Bash (background).
 
-Each LLM's analysis prompt MUST include these instructions:
-- **Breadth first, depth second**: Identify ALL subtopics and angles before deep-diving into any single area
-- **"Use web search EXTENSIVELY — do NOT rely solely on your training data"**
-- **Iterative research**: Continue researching until genuinely done, then append `<!-- RESEARCH_COMPLETE -->` as a completion signal
-- **Gap identification**: On each continuation, explicitly identify what's MISSING from the analysis so far before adding new content
+Save outputs to `{llm}-analysis.md`. 10-minute timeout per external LLM. Continue with whatever succeeded — minimum floor is Claude.
 
-#### Concrete Invocations
+### Fatal-error watch
 
-Launch all three simultaneously:
-
-- **Claude**: Task agent with `max_turns: 50` and `subagent_type: "general-purpose"`. Prompt includes: "When your research is genuinely complete — all subtopics covered, sources verified, gaps addressed — append `<!-- RESEARCH_COMPLETE -->` at the end of your output."
-- **Gemini**: `timeout 600 gemini -m <gemini-flagship from registry> --approval-mode yolo` with the research prompt piped to stdin via Bash (background)
-- **Codex**: `echo "<prompt>" | codex exec --skip-git-repo-check -m <codex-flagship from registry> --reasoning-effort xhigh --full-auto 2>/dev/null` via Bash (background)
-
-Save outputs to `{llm}-analysis.md`. 10-minute timeout per external LLM. Graceful degradation: continue with successful analyses (minimum: Claude).
-
-#### Fatal Error Detection
-
-After launching Gemini and Codex in background, start a Monitor for each to detect fatal errors early. For each external LLM, after launching via `Bash` with `run_in_background`, start a Monitor:
+For each external LLM, start a `Monitor` after launching the background process. This catches quota/auth errors early so you can stop waiting:
 
 ```
 Monitor (one per LLM):
@@ -212,71 +109,54 @@ Monitor (one per LLM):
         done
 ```
 
-On `FATAL|{llm_name}|{pattern}` notification: kill the corresponding background process, log the detected pattern, mark that LLM as failed, and continue with remaining LLMs.
+On a `FATAL|{llm_name}|{pattern}` notification, kill the background process, log the pattern, mark that LLM failed, and proceed with the survivors.
 
----
+## Phase 3 — Cross-Pollination Refinement
 
-### Phase 3: Cross-Pollination Refinement (NEW)
+Each LLM that produced a Phase 2 analysis reads all surviving analyses (its own + peers') and writes a strictly-better refined version. Only Phase-2 survivors participate.
 
-After all Phase 2 analyses are saved, launch a refinement round where each surviving LLM reads ALL analyses (its own + peers') and produces a refined version.
+Refinement prompt instructions:
 
-#### Refinement Prompt
+1. Read your own analysis — know its strengths and weaknesses.
+2. Read peers **with healthy skepticism** — look for missed angles, deeper coverage, weakly sourced claims, contradictions, unique sources.
+3. Conduct *new* research on avenues peers inspired, contradictions needing resolution, shared gaps.
+4. Produce a refined version that is strictly better than the original.
 
-Each LLM gets a prompt with ALL `{llm}-analysis.md` files embedded, plus these instructions:
+Rules embedded in the prompt:
+- Don't copy content from peers.
+- Don't accept peer claims at face value — verify via web search.
+- Use peer findings as a springboard for new investigation, not a summary target.
+- Cover territory neither analysis adequately addressed.
+- Keep your unique perspective — don't homogenize.
 
-1. Read your own analysis — understand its strengths and weaknesses
-2. Read peer analyses **with healthy skepticism** — look for missed angles, deeper coverage, weakly sourced claims, contradictions, unique sources
-3. **Conduct NEW research** on avenues inspired by peer work, contradictions needing resolution, shared gaps
-4. Write a refined version that is **strictly better** than the original
+Invocations mirror Phase 2 (same registry IDs). Save to `{llm}-refined.md`. Same timeouts and fatal-error watch. If refinement fails for any LLM, fall back to its `{llm}-analysis.md` for synthesis.
 
-Critical rules included in the prompt:
-- "Do NOT simply copy content from peer analyses"
-- "Do NOT accept peer claims at face value — verify independently via web search"
-- "Use peer findings as a SPRINGBOARD for NEW investigation"
-- "Explore territory that NEITHER analysis adequately covered"
-- "Maintain your unique perspective — don't homogenize"
+## Phase 4 — Synthesis
 
-#### Concrete Invocations
+Spawn the `research-synthesizer` agent with all refined reports (or originals where refinement failed). The synthesizer organizes findings by **theme**, not by source LLM, and inline-attributes using:
+- `[Consensus: 3/3]`, `[Consensus: 2/3]` for agreement
+- `[Claude]`, `[Gemini]`, `[Codex]` for single-source findings
 
-Same CLI patterns as Phase 2 (use the same resolved model IDs from the registry):
-- **Claude**: Task agent with `max_turns: 50`, `subagent_type: "general-purpose"`
-- **Gemini**: `timeout 600 gemini -m <gemini-flagship from registry> --approval-mode yolo` (background)
-- **Codex**: `echo "<prompt>" | codex exec --skip-git-repo-check -m <codex-flagship from registry> --reasoning-effort xhigh --full-auto 2>/dev/null` (background)
+In swarm mode, discovery-phase findings also carry `[Locator]` / `[Analyzer]` / `[Pattern Finder]` tags; the synthesizer preserves them in the Discovery section.
 
-Save to `{llm}-refined.md`. Same timeout and fatal error detection rules as Phase 2. If refinement fails for any LLM, fall back to its original `{llm}-analysis.md` for synthesis.
+Save to `research/research-{topic-kebab}-deep.md` with YAML frontmatter. Add GitHub permalinks where applicable. Close with a short report: which LLMs contributed, which phases succeeded, and which findings are consensus vs unique.
 
-Only LLMs that produced a successful Phase 2 analysis participate in Phase 3.
+### Storage layout
 
----
-
-### Phase 4: Synthesis
-
-- Spawn research-synthesizer agent to merge refined reports (or originals if refinement failed)
-- Synthesis organizes findings by **theme**, not by source LLM
-- Use LLM attribution inline within themed sections: `[Consensus: 3/3]`, `[Consensus: 2/3]`, `[Claude]`, `[Gemini]`, `[Codex]`
-- **If `SWARM_MODE` was active**: Also include team attribution alongside LLM attribution. In the synthesis document, note that Discovery used an agent team and which teammates contributed. Team attribution (`[Locator]`, `[Analyzer]`, `[Pattern Finder]`) appears in the Discovery findings sections; LLM attribution appears in the Analysis sections.
-- Save to `research/research-{topic-kebab-case}-deep.md` with YAML frontmatter
-- Add GitHub permalinks if applicable
-- Report which LLMs contributed, which phases succeeded, and highlight consensus vs unique discoveries
-
-**Storage structure:**
 ```
 research/.deep-research-[timestamp]/
-├── context.md              # Discovery output (from subagents OR team)
-├── claude-analysis.md      # Phase 2: Claude independent analysis
-├── gemini-analysis.md      # Phase 2: Gemini independent analysis
-├── codex-analysis.md       # Phase 2: Codex independent analysis
-├── claude-refined.md       # Phase 3: Claude cross-pollinated refinement
-├── gemini-refined.md       # Phase 3: Gemini cross-pollinated refinement
-└── codex-refined.md        # Phase 3: Codex cross-pollinated refinement
+├── context.md              # Discovery output (from subagent or team)
+├── claude-analysis.md      # Phase 2
+├── gemini-analysis.md      # Phase 2
+├── codex-analysis.md       # Phase 2
+├── claude-refined.md       # Phase 3
+├── gemini-refined.md       # Phase 3
+└── codex-refined.md        # Phase 3
 ```
 
-## References
+## Scope
 
-Load documentarian constraints via:
-- `Glob(pattern: "**/sdlc/**/references/documentarian-constraints.md", path: "~/.claude/plugins")` → Read result
-
-Fallback if file not found: Document codebase as it exists. Do not suggest improvements, propose enhancements, or critique implementation.
+This command documents the codebase as it is. Don't propose improvements or critique implementation unless the user explicitly asks — that's what `/review` is for. Load the canonical constraints via `Glob(pattern: "**/sdlc/**/references/documentarian-constraints.md", path: "~/.claude/plugins")` and read the result; if the file isn't found, apply the rule inline: document what is, not what should be.
 
 ## Topic
 

--- a/commands/research.md
+++ b/commands/research.md
@@ -1,190 +1,135 @@
 # Research & Document Codebase
 
-## Session Naming
+## Role
 
-`/rename "Research: $ARGUMENTS"` (or infer from context)
+Produce a standalone research document in `research/` that answers a question about this codebase, with every finding backed by `file:line` references. Document what *is*, not what *should be*.
 
 ## Priorities
 
 Precision (file:line refs) > Completeness (trace full paths) > Concision
 
-## Goal
+## Scope
 
-Research and document the codebase to answer the given question. Produce a standalone research document in `research/` with findings backed by file:line references.
+Load canonical documentarian constraints: `Glob(pattern: "**/sdlc/**/references/documentarian-constraints.md", path: "/Users/iamladi/Projects/claude-code-plugins")` and read the result. The core rule: this command documents the codebase as it exists, not as it should exist. Don't propose improvements, critique implementation, or suggest refactors unless the user explicitly asks — those belong in `/review` or `/plan`.
 
-## Constraints
+## Session setup
 
-Read documentarian constraints (Glob `**/sdlc/**/references/documentarian-constraints.md`, path `/Users/iamladi/Projects/claude-code-plugins`). YOUR ONLY JOB IS TO DOCUMENT AND EXPLAIN THE CODEBASE AS IT EXISTS TODAY. DO NOT suggest improvements or changes unless explicitly requested. Document what IS, not what SHOULD BE.
+`/rename "Research: $ARGUMENTS"` — or, if no topic was supplied, ask first, then rename.
 
-### CRITICAL: Route Selection
+## Routing
 
-BEFORE taking any other action, check `$ARGUMENTS` for the `--no-swarm` flag:
+Swarm is the default — research usually benefits from teammates sharing discoveries in real time. Pass `--no-swarm` to fall back to a solo parallel-subagent flow. Strip `--no-swarm` from the args; the remainder is the research topic. If nothing remains, ask the user for a research question.
 
-1. If `--no-swarm` IS present: remove it from the arguments (the remaining text is the research topic), then skip directly to **Standard Workflow**. Do NOT execute any Swarm Workflow steps.
-2. If `--no-swarm` is NOT present: the full `$ARGUMENTS` is the research topic, skip directly to **Swarm Workflow**. Do NOT execute any Standard Workflow steps.
+If swarm mode is active but `TeamCreate` isn't available, tell the user:
+```
+Swarm mode requires agent teams. Set CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in settings.json or environment.
+Falling back to standard workflow.
+```
+Then continue — the topic is already parsed.
 
-If no research topic remains after processing, ask the user for a research question before proceeding.
+## Interview checkpoint (both modes)
 
----
+Find and run the interview protocol:
+- `Glob(pattern: "**/sdlc/**/skills/interview/SKILL.md", path: "~/.claude/plugins")`
 
-## Swarm Workflow
+Run in context-only mode: no file updates, no Interview Insights section. Focus on scope, focus areas, depth vs breadth, intended use of the research output. Topic is the parsed research question. Carry interview decisions into the spawn prompts so teammates inherit the scope.
 
-An alternative approach using agent teams for research that benefits from dynamic collaboration between teammates. This works well when the research question requires teammates to share discoveries in real-time rather than working in isolation.
+## Context gathering (both modes)
 
-### Team Prerequisites and Fallback
-
-Attempt to create the agent team using `TeamCreate` with a unique timestamped name: `research-{topic-kebab}-{YYYYMMDD-HHMMSS}` and description: "Research: {topic}".
-
-If team creation fails (tool unavailable or experimental features disabled), inform the user that swarm mode requires agent teams to be enabled (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in settings.json), then fall back to executing the Standard Workflow instead. The research topic is already parsed and ready to use.
-
-### Interview Checkpoint
-
-Find and read the interview protocol using Glob:
-- Pattern: `**/sdlc/**/skills/interview/SKILL.md`
-- Search path: `~/.claude/plugins`
-
-Execute the interview protocol with these overrides:
-- Output to conversation context only — do not update files or write an Interview Insights section
-- Focus on: research scope, focus areas, depth vs breadth, intended use of research output
-- The topic for the interview is: the research topic as parsed from $ARGUMENTS
-
-### Context Preparation
-
-Before spawning teammates, read any user-mentioned files completely and understand the research question. Summarize this context in the teammate spawn prompts so they start with shared understanding.
-
-Include interview decisions and focus areas when summarizing context in the teammate spawn prompts.
-
-### Shared Task List
-
-Create tasks via `TaskCreate` that represent the key unknowns you need answered:
-1. **Locate relevant files** — coverage goal is finding ALL files related to the topic
-2. **Analyze implementation details** — depth goal is understanding HOW it works
-3. **Find patterns and conventions** — breadth goal is discovering SIMILAR implementations
-
-These tasks provide structure without prescribing the investigation approach.
-
-### Teammate Roles
-
-Spawn 3 teammates via the `Task` tool with `team_name` parameter and `subagent_type: "general-purpose"`. Each teammate has a different lens on the research question:
-
-**Teammate 1: Locator**
-
-Your role is to find ALL files, directories, and components relevant to "{topic}". Success means the team knows WHERE to look, not just some places but everywhere this topic touches the codebase.
-
-Approach this with multiple search strategies — don't rely on a single grep pattern. Try different naming conventions, file extensions, and related concepts. Categorize what you find (implementation, tests, config, types, docs) so teammates know what matters most.
-
-When you discover files that teammates should examine, tell them via SendMessage. When you've achieved comprehensive coverage, mark your task complete via TaskUpdate and send "RESEARCH COMPLETE". All findings must include full file paths.
-
-**Teammate 2: Analyzer**
-
-Your role is to understand HOW "{topic}" works — trace the actual execution paths, data flow, and component interactions. Success means the team understands the implementation mechanics, not just the surface API.
-
-Read files thoroughly before making statements. Follow the code paths to see what actually happens. Every claim you make should cite file:line references that prove it.
-
-Focus on the "how" questions: Where are the entry points? What's the core logic? How does data flow through? What error handling exists? How do components interact?
-
-When you discover patterns worth documenting or realize files are missing from the team's awareness, share via SendMessage. When you've achieved sufficient depth to explain the implementation, mark your task complete via TaskUpdate and send "RESEARCH COMPLETE".
-
-**Teammate 3: Pattern Finder**
-
-Your role is to find similar implementations, usage examples, and existing patterns that illuminate "{topic}". Success means the team sees HOW this topic fits into broader codebase conventions and where to find working examples.
-
-Show actual working code examples with file:line references, not just snippets. When multiple variations exist, show them — the differences often reveal important context. Categorize patterns by type: API patterns, data patterns, component patterns, testing patterns.
-
-When you find patterns the Analyzer should trace or files the Locator missed, share via SendMessage. When you've achieved sufficient breadth to show the patterns and conventions, mark your task complete via TaskUpdate and send "RESEARCH COMPLETE".
-
-### Mandatory Web Research
-
-Spawn a `web-search-researcher` subagent (NOT a teammate) in parallel with the team. This runs independently and may complete on a different timeline. Web search always runs to provide external evidence alongside codebase findings. If web search fails or returns no results, proceed with codebase-only findings.
-
-### Completion Criteria and Convergence
-
-Teammates signal completion by sending "RESEARCH COMPLETE" messages. Wait up to 10 minutes from teammate spawn time for all three to complete. If a teammate hasn't signaled completion by timeout, proceed with available findings and note which teammates timed out in the output.
-
-**Web research timing**: If the web-search-researcher is still running when all three teammates complete, wait up to 2 additional minutes. If it hasn't finished, proceed without it. Web research is supplementary — it always runs but never blocks command completion.
-
-**Fallback behavior**: If a teammate fails or gets stuck in a loop (indicated by repeated similar messages or no progress), you have three options: (1) note the failure and proceed with other teammates' findings, (2) spawn a replacement teammate with clearer scoped instructions, or (3) handle that aspect of research yourself. Choose based on how critical that role's findings are to answering the research question.
-
-### Synthesis Principles
-
-As team lead, your job is to integrate teammate findings into a coherent answer to the research question, not mechanically merge their outputs.
-
-**Attribution strategy**: Use team attribution markers in body sections: `[Locator]`, `[Analyzer]`, `[Pattern Finder]`. Mark independently confirmed findings `[Consensus]`.
-
-**Preserve provenance**: All file:line references from teammates must appear in the final document.
-
-**Output format**: The research document structure is identical to Standard Workflow output (same YAML frontmatter schema, same required sections). In the Summary section, briefly note team composition and which teammates contributed. Attribution markers belong in body sections, NOT in YAML frontmatter.
-
-### Resource Cleanup
-
-After completing synthesis (whether successful or failed), always clean up team resources. This prevents lingering agent processes and task lists from accumulating.
-
-Send shutdown requests to all teammates via `SendMessage` with `type: "shutdown_request"`, wait briefly for confirmations, then call `TeamDelete` to remove the team and its task list.
-
-If cleanup itself fails, inform the user: "Team cleanup incomplete. You may need to check for lingering team resources."
-
-Execute cleanup regardless of synthesis outcome — even if earlier steps errored or teammates timed out, cleanup must run before ending.
+Read any user-mentioned files completely (no limit/offset) before spawning anything. Teammates need to inherit shared grounding, and you can't summarize what you haven't read.
 
 ---
 
-## Standard Workflow
+## Swarm workflow
 
-The default research approach uses specialized subagents to explore different aspects of the codebase in parallel.
+Create the team with `TeamCreate`: name `research-{topic-kebab}-{YYYYMMDD-HHMMSS}`, description `Research: {topic}`.
 
-### Interview Checkpoint
+Register three shared tasks via `TaskCreate` — structure without prescribing investigation approach:
+1. **Locate relevant files** — coverage goal: find all files related to the topic.
+2. **Analyze implementation details** — depth goal: understand how it works.
+3. **Find patterns and conventions** — breadth goal: surface similar implementations.
 
-Find and read the interview protocol using Glob:
-- Pattern: `**/sdlc/**/skills/interview/SKILL.md`
-- Search path: `~/.claude/plugins`
+Spawn three teammates via `Task` with `team_name` and `subagent_type: "general-purpose"`. In parallel, spawn `web-search-researcher` as a plain subagent (no `team_name`) — it supplements but never blocks.
 
-Execute the interview protocol with these overrides:
-- Output to conversation context only — do not update files or write an Interview Insights section
-- Focus on: research scope, focus areas, depth vs breadth, intended use of research output
-- The topic for the interview is: the research topic as parsed from $ARGUMENTS
+### Teammate briefs
 
-### Context Gathering
+<example name="Locator">
+Your role is to find all files, directories, and components relevant to "{topic}". Success means the team knows where to look — not some places, everywhere this topic touches the codebase.
 
-Read any files the user mentioned completely before delegating work. This provides grounding for the subagents and ensures you understand what the user is starting from.
+Use multiple search strategies; don't rely on a single grep pattern. Try different naming conventions, file extensions, and related concepts. Categorize what you find (implementation, tests, config, types, docs) so teammates know what matters most. Share discoveries via `SendMessage` when teammates should examine what you've surfaced. All findings include full file paths. When coverage is comprehensive, `TaskUpdate` to mark complete and send `RESEARCH COMPLETE`.
+</example>
 
-Include interview decisions and focus areas when summarizing context for subagent prompts.
+<example name="Analyzer">
+Your role is to understand how "{topic}" works — trace the actual execution paths, data flow, and component interactions. Success means the team understands the implementation mechanics, not just the surface API.
 
-### Parallel Investigation
+Read files thoroughly before making statements. Follow the code paths to see what actually happens. Every claim cites `file:line`. Focus on: Where are the entry points? What's the core logic? How does data flow through? What error handling exists? How do components interact?
 
-Spawn subagents with complementary perspectives on the research question:
-- **Locator**: Discovers where relevant code lives (files, directories, components)
-- **Analyzer**: Understands how the code works (data flow, interactions, implementation)
-- **Pattern Finder**: Identifies conventions and similar implementations elsewhere
-- **Web Search Researcher**: Finds external evidence, best practices, and current documentation from web sources
+Share patterns worth documenting or missing files via `SendMessage`. When you can explain the implementation, `TaskUpdate` to mark complete and send `RESEARCH COMPLETE`.
+</example>
 
-These roles work best when they have judgment latitude about HOW to investigate, while being clear on WHAT they're investigating. Each subagent should determine its own search strategy based on what it discovers.
+<example name="Pattern Finder">
+Your role is to find similar implementations, usage examples, and existing patterns that illuminate "{topic}". Success means the team sees how this topic fits into broader codebase conventions and where to find working examples.
 
-The web-search-researcher always runs in parallel with codebase subagents. If web search fails or returns no results, the command proceeds with codebase-only findings.
+Show actual working code with `file:line` references, not just snippets. When multiple variations exist, show them — the differences often reveal context. Categorize: API, data, component, testing patterns. Share leads with the Analyzer and Locator via `SendMessage`. When breadth is sufficient, `TaskUpdate` to mark complete and send `RESEARCH COMPLETE`.
+</example>
 
-### Source Requirements
+### Convergence
 
-All findings must trace back to specific locations in the codebase (file:line references). Prioritize the live codebase over existing documentation when they conflict — code is the source of truth.
+Wait for all three teammates to send `RESEARCH COMPLETE`, up to 10 minutes per teammate from spawn. On teammate timeout, proceed with available findings and note the timeout in the output. If a teammate gets stuck (repeated identical messages, no progress), pick: note the failure and proceed, respawn with tighter scope, or handle that role yourself — decide on criticality.
+
+Web research gets up to 2 extra minutes after teammates finish. Then proceed without it — it always runs, never blocks.
 
 ### Synthesis
 
-Wait for all subagents to complete their investigation (including web-search-researcher). If web search is still running when codebase subagents finish, wait up to 2 additional minutes before proceeding without it. Integrate all findings — codebase analysis and web search results — into a coherent research document that answers the original question, preserving all source attributions.
+Integrate findings into a coherent answer to the research question — not a mechanical merge.
+
+- Use body-section attribution: `[Locator]`, `[Analyzer]`, `[Pattern Finder]`. Independently confirmed findings get `[Consensus]`.
+- Preserve every `file:line` reference from teammates in the final document.
+- Note team composition and contributors briefly in the Summary section. Attribution markers live in the body, not in YAML frontmatter.
+
+### Cleanup invariant
+
+**The team must be deleted before the command returns, regardless of whether synthesis succeeded.** Skipping leaks team slots and orphans the shared task list.
+
+1. `SendMessage` with `type: "shutdown_request"` to each teammate.
+2. Wait briefly for shutdown confirmations.
+3. `TeamDelete`.
+
+If cleanup itself errors, tell the user `"Team cleanup incomplete. You may need to check for lingering team resources."` and continue.
+
+---
+
+## Standard workflow
+
+Spawn subagents with complementary perspectives on the research question, in parallel:
+- **Locator** — discovers where relevant code lives (files, directories, components).
+- **Analyzer** — understands how the code works (data flow, interactions, implementation).
+- **Pattern Finder** — identifies conventions and similar implementations elsewhere.
+- **Web Search Researcher** — finds external evidence, best practices, and current documentation.
+
+Each subagent has judgment latitude on *how* to investigate; be clear on *what* they're investigating. They decide their own search strategy based on what they find. Include interview decisions and focus areas in each spawn prompt.
+
+The web-search-researcher always runs in parallel; if it fails or returns nothing, proceed with codebase-only findings. If it's still running when codebase subagents finish, give it up to 2 extra minutes.
+
+All findings must trace to specific `file:line` locations. When the codebase and existing documentation disagree, the codebase is the source of truth.
+
+Integrate all results — codebase analysis + web search — into a single coherent document, preserving every source attribution.
 
 ---
 
 ## Output
 
-Save to `research/research-[topic-kebab-case].md` with YAML frontmatter (date, git_commit, branch, repository, topic, tags, status, last_updated, last_updated_by).
+Save to `research/research-[topic-kebab-case].md` with YAML frontmatter: `date`, `git_commit`, `branch`, `repository`, `topic`, `tags`, `status`, `last_updated`, `last_updated_by`.
 
-Required sections: Research Question → Summary → Detailed Findings (with file:line) → Code References → Architecture Documentation → Related Research → Open Questions.
+Required sections: Research Question → Summary → Detailed Findings (with `file:line`) → Code References → Architecture Documentation → Related Research → Open Questions.
 
-Add GitHub permalinks if on pushed branch: `https://github.com/{owner}/{repo}/blob/{commit}/{file}#L{line}`
+Add GitHub permalinks if the branch is pushed: `https://github.com/{owner}/{repo}/blob/{commit}/{file}#L{line}`.
 
-For follow-ups: append to same doc, update frontmatter, add `## Follow-up Research [timestamp]`.
+For follow-ups: append to the same doc, update frontmatter, add `## Follow-up Research [timestamp]`.
 
-**Swarm mode additions**: When `--swarm` was used, add to the Summary section a brief note on team composition and which teammates contributed. Attribution markers go in body sections, NOT in YAML frontmatter.
+When `--no-swarm` wasn't used (swarm was active), the Summary also carries a short line on team composition and which teammates contributed.
 
-## References
-
-- `**/sdlc/**/references/documentarian-constraints.md` — Documentarian role boundaries
+Close with a brief summary of findings and the path to the saved research document.
 
 ## Idea
 
@@ -192,6 +137,4 @@ $ARGUMENTS
 
 ## Report
 
-If no idea: "I'm ready to research the codebase. Please provide your research question."
-
-After completion: summary of findings, path to research document.
+If no idea: `"I'm ready to research the codebase. Please provide your research question."`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-plugin",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations",
   "private": true,
   "type": "module",

--- a/plans/opus-4-7-refactor.md
+++ b/plans/opus-4-7-refactor.md
@@ -1,0 +1,150 @@
+# Opus 4.7 Refactor — sdlc-plugin
+
+## Context
+
+Anthropic shipped Claude Opus 4.7 (`claude-opus-4-7`, 1M-token variant available). Prompts in this repo were tuned for 4.5/4.6 and earlier. 4.7 behaves differently enough that old scaffolding actively hurts output quality. The repo already started migrating — `#57` rewrote the interview skill for 4.7 and `#51` rewrote the review command with research citations and targeted failure probes. This plan continues that trajectory across the rest of sdlc-plugin.
+
+**Why now:** 4.7 is more literal, less implicit-generalizing, trends toward fewer tool calls, and has breaking API changes (sampling params, prefill, `budget_tokens` all removed). Defensive scaffolding that "just worked" on 4.6 now produces over-triggering, suppressed findings, or outright degraded reasoning.
+
+**Intended outcome:** (a) a workspace-level principles doc so future prompts start on-spec, (b) full rewrites of the highest-friction sdlc-plugin commands, (c) surgical passes on borderline cases. Scope stays in `sdlc-plugin/` per user decision.
+
+---
+
+## Opus 4.7 deltas that matter for prompt design
+
+Sourced from platform.claude.com docs, the Jan-2026 Claude Constitution, and Anthropic's 4.7 migration guide (see `OPUS_4_7_PROMPTING.md` for URLs).
+
+| Area | 4.6 behavior | 4.7 behavior | Prompt implication |
+|---|---|---|---|
+| Literalness | Generalizes instruction to similar items | Applies only to stated scope | State scope explicitly ("all items", "every section") |
+| Tool calls | Eager, especially with "always use X" | Trends to fewer, more internal reasoning | Remove "aggressive anti-laziness"; raise effort + explicit parallel-tool guidance where needed |
+| Sampling | `temperature`, `top_p`, `top_k` supported | All return 400 | Shape via prompt, not knobs |
+| Thinking | `budget_tokens` | Adaptive only, controlled by `effort` | Remove "think step by step" compensation phrases; raise effort instead |
+| Prefill | Assistant-message prefill allowed | Returns 400 | Replace with system-prompt instruction: "respond directly, no preamble" |
+| Tokenizer | Baseline | ~1x–1.35x more tokens per unit text | Re-check any hardcoded token budgets |
+| Rule style | Tolerates MUST/NEVER walls | Brittle under threat-phrased rules | Explain *why*, not bark commands |
+| Code review | Filters per "report only high-sev" | Will suppress findings aggressively | Decouple find-stage from filter-stage |
+
+## Refactor principles (content for `OPUS_4_7_PROMPTING.md`)
+
+The deliverable principles doc will capture these as the canonical "how we write prompts for 4.7 in this workspace" reference.
+
+1. **Onboarding-doc structure over rule-lists.** Open with role + why this role exists + what success looks like, then reasoning examples, then edge cases. Model after `sdlc-plugin/skills/interview/SKILL.md` (85 lines) and `sdlc-plugin/agents/implementer.md` (84 lines).
+2. **Explain *why* inline with any constraint.** "Never mock the DB in integration tests — mocked tests passed in Q3 while the prod migration broke" beats "NEVER MOCK THE DB."
+3. **State scope explicitly.** 4.7 will not generalize "apply formatting" across all sections unless told.
+4. **Drop compensation phrases.** Remove "think step by step", "take your time", "be thorough" — these compensated for pre-4.x reasoning gaps and now just add noise. Raise `effort` where depth is needed.
+5. **Don't weaponize caps.** Replace `CRITICAL:`, `MUST`, `NEVER` with reasoned prose unless quoting an error or protocol ID. Keep caps for genuine destructive-op warnings.
+6. **Remove defensive step-numbering where the model can plan.** "Step 1 do X, Step 2 do Y, Step 3…" invites overtriggering. Keep step-numbered protocols only where sequence correctness is load-bearing (e.g. team-cleanup ordering).
+7. **Separate find from filter in review/audit prompts.** Per the 4.7 code-review guidance — have the prompt collect findings with confidence + severity, and do the filtering in a downstream pass.
+8. **Cite evidence when recommending a pattern.** `commands/review.md` is the template — "13% vs 100% bug catch rates" anchors the protocol in data, not vibes.
+9. **Trust tool output; don't replicate tool logic.** `skills/de-slop` delegates to `desloppify` cleanly. Mirror this for `codex`, `gemini`, `update-models`.
+10. **Parallel tool calls: be explicit when needed.** 4.7 defaults conservatively. Add a one-liner where fan-out matters.
+11. **Anti-sycophancy / no preamble.** Put "respond directly, no preamble" in the system prompt now that prefill is gone.
+12. **XML tags for mixed-content prompts.** `<instructions>`, `<context>`, `<examples>`, `<constraints>` reduce misread on long commands like `implement.md`.
+
+## sdlc-plugin file triage
+
+Rankings combine line count, `MUST/NEVER/ALWAYS/CRITICAL` density, step-number rigidity, and whether the file is on the hot path (commands/agents used every session).
+
+### Tier 1 — Full rewrite (reasoning-based, modeled on interview.md / review.md)
+
+| File | Lines | Why it qualifies |
+|---|---|---|
+| `commands/research-deep.md` | 283 | 5 CRITICAL/MUST tokens; rigid Step 1–7 per mode; swarm/standard branching logic the model can own; exhaustive cleanup guards |
+| `commands/implement.md` | 292 | 3 CRITICAL/MUST; dual-mode scaffolding; prescriptive TDD injection sequence; subagent-dispatch logic spelled out line-by-line |
+| `commands/research.md` | 197 | Rigid routing (`--no-swarm`) at top; "YOUR ONLY JOB" all-caps; overlap with research-deep |
+| `commands/plan.md` | 151 | Phased planning scaffolding the model should orchestrate from goals |
+| `skills/judgment-eval/SKILL.md` | 202 | High-value skill, worth modernizing to 4.7 evaluation style (find-then-filter) |
+| `skills/system-prompt-clinic/SKILL.md` | 188 | Already a reasoning-based skill but predates 4.7 patterns — align with principles doc |
+
+### Tier 2 — Surgical pass (keep structure, strip anti-patterns)
+
+| File | Lines | Move |
+|---|---|---|
+| `commands/verify.md` | 31 | Audit for caps/MUST, align wording |
+| `commands/submit.md` | 26 | Same |
+| `skills/tdd/SKILL.md` | 133 | Align TDD framing with 4.7 effort model; keep mode semantics |
+| `skills/codex/SKILL.md` + references | 51+56 | Ensure registry delegation is explicit; strip compensation phrases |
+| `skills/gemini/SKILL.md` + references | 52+132 | 2 CRITICAL tokens — review |
+| `skills/x-search/SKILL.md` + refs | 78+112 | Light touch |
+| `skills/agent-change-walkthrough/SKILL.md` | 52 | Light touch |
+| `skills/update-models/SKILL.md` | 22 | Light touch |
+| `skills/finish-branch/SKILL.md` | 48 | Light touch |
+| `skills/test/SKILL.md` + references | 86+441 | Big reference file; audit for 4.7 alignment without rewriting test-patterns.md from scratch |
+| `skills/constitution-compliance-review/*` | 129+557+74 | Already constitution-aligned; audit scoring rubric wording |
+| `agents/*` (9 files, 34–86 lines each) | — | Most already lean. Verify against principles. `spec-reviewer.md` and `code-quality-reviewer.md` are worth extra attention since they drive the review pipeline. |
+
+### Tier 3 — Reference / leave alone
+
+| File | Why |
+|---|---|
+| `skills/interview/SKILL.md` | Already Opus 4.7 template (#57) |
+| `commands/review.md` | Already Opus 4.7 template (#51) |
+| `agents/implementer.md` | Already onboarding-doc style |
+
+## Per-file refactor notes — Tier 1
+
+### `commands/research-deep.md`
+- Collapse "Step 1–7" into a goal block + cleanup invariant. The model can own the sequence if we state the invariant: "Team must be deleted before returning control, regardless of success/failure."
+- Replace `SWARM_MODE=true/false` imperative branching with: "If `--swarm` passed, use agent teams; otherwise work directly. On team failure, fall back to direct work."
+- Strip `CRITICAL:`, `DO NOT`, `MUST` — restate as reasoned guidance.
+- Delete per-step "mandatory" reminders; keep the cleanup invariant as a single prominent line.
+
+### `commands/implement.md`
+- Replace "Subagent Workflow step 1–N" with a role statement ("You orchestrate; implementers execute"), then success criteria, then a worked example of one task loop.
+- TDD injection: move from "read mocking.md, inject boundary-only rule" to "pass the TDD reference docs to the implementer; they're trusted to apply them." Trust the agent.
+- Fold `Standard Workflow` / `Swarm Workflow` into one flow with a branching paragraph.
+
+### `commands/research.md`
+- Same routing cleanup as research-deep.
+- Remove "YOUR ONLY JOB IS TO DOCUMENT" caps-lock wall — replace with a short "scope" paragraph explaining why documentarian mode exists (prevents unsolicited refactors during research).
+
+### `commands/plan.md`
+- Audit phase scaffolding. Likely can compress similarly.
+
+### `skills/judgment-eval/SKILL.md`
+- Apply find-then-filter separation to scenario evaluation.
+- Align with 4.7 effort model: scenarios benefit from `high` effort, call that out explicitly.
+
+### `skills/system-prompt-clinic/SKILL.md`
+- Already reasoning-based. Ensure its transformation patterns reference the new `OPUS_4_7_PROMPTING.md` principles so outputs produced by the clinic land on-spec.
+
+## Deliverables
+
+1. **`OPUS_4_7_PROMPTING.md`** — new file at workspace root `/Users/iamladi/Projects/claude-code-plugins/OPUS_4_7_PROMPTING.md`. Contains the principles section above plus sourced URLs, plus two worked before/after examples (one command, one skill). Canonical reference going forward.
+2. **Tier 1 rewrites** — 6 files rewritten in-place in `sdlc-plugin/commands/` and `sdlc-plugin/skills/*/SKILL.md`.
+3. **Tier 2 surgical passes** — batch edits across the remaining files to strip anti-patterns without restructuring.
+
+Commits grouped per file (or per coherent pair). Conventional commits, `refactor:` prefix.
+
+## Verification
+
+- **Principles doc**: run `skills/constitution-compliance-review` against it once drafted; target score ≥ baseline for the `prompt-as-onboarding` skill.
+- **Each Tier 1 rewrite**: run `skills/judgment-eval` with 3 scenarios covering happy path + two edge cases; compare against current version.
+- **Behavioral spot-check**: for `research-deep.md` and `implement.md`, do one dry run each against a small real task and observe tool-call density + output quality vs. current version.
+- **CI / validation**: `bun run validate` from workspace root to confirm plugin manifest still parses.
+- **Git hygiene**: `git log --oneline` per commit; confirm commits are scoped per file/pair, not omnibus.
+
+## Critical files to modify
+
+- `/Users/iamladi/Projects/claude-code-plugins/OPUS_4_7_PROMPTING.md` (new)
+- `/Users/iamladi/Projects/claude-code-plugins/sdlc-plugin/commands/research-deep.md`
+- `/Users/iamladi/Projects/claude-code-plugins/sdlc-plugin/commands/implement.md`
+- `/Users/iamladi/Projects/claude-code-plugins/sdlc-plugin/commands/research.md`
+- `/Users/iamladi/Projects/claude-code-plugins/sdlc-plugin/commands/plan.md`
+- `/Users/iamladi/Projects/claude-code-plugins/sdlc-plugin/skills/judgment-eval/SKILL.md`
+- `/Users/iamladi/Projects/claude-code-plugins/sdlc-plugin/skills/system-prompt-clinic/SKILL.md`
+
+## Reference files to reuse as templates
+
+- `/Users/iamladi/Projects/claude-code-plugins/sdlc-plugin/skills/interview/SKILL.md` — onboarding-doc structure, `<thinking>` example
+- `/Users/iamladi/Projects/claude-code-plugins/sdlc-plugin/commands/review.md` — evidence-backed protocol, find-then-filter split
+- `/Users/iamladi/Projects/claude-code-plugins/sdlc-plugin/agents/implementer.md` — lean role + success criteria
+- `/Users/iamladi/Projects/claude-code-plugins/primitives-plugin/skills/prompt-as-onboarding/SKILL.md` — canonical onboarding-doc skill
+- `/Users/iamladi/Projects/claude-code-plugins/primitives-plugin/skills/de-slop/SKILL.md` — tool-delegation pattern
+
+## Out of scope (flagged for later)
+
+- Refactor of sibling plugins (`github`, `workflows`, `primitives`, `ts`, `misc`) — deferred per user.
+- Workspace-level `CLAUDE.md` updates — may need a pointer to `OPUS_4_7_PROMPTING.md` but not a rewrite.
+- Global user `~/.claude/CLAUDE.md` — out of scope.

--- a/references/blindspot-review-protocol.md
+++ b/references/blindspot-review-protocol.md
@@ -5,7 +5,7 @@
 
 After creating the draft plan, run it through Codex and Gemini in parallel to uncover blindspots.
 
-**IMPORTANT**: Spawn both review agents in a single message to run them in parallel.
+Spawn both review agents in a single message so they run concurrently — serial review roughly doubles wall-clock time for no signal gain.
 
 ### Codex Plan Critic
 
@@ -99,7 +99,7 @@ $(cat plans/[plan-file].md)"
 
 ### Wait and Consolidate
 
-**CRITICAL**: Wait for BOTH critics to complete before proceeding.
+Wait for both critics to complete before consolidating. Partial consolidation drops findings from whichever reviewer hadn't returned yet.
 
 Consolidate their feedback:
 1. **Parse findings** from each critic

--- a/skills/gemini/SKILL.md
+++ b/skills/gemini/SKILL.md
@@ -20,12 +20,11 @@ Load current models before executing — this overrides any model names in the t
 
 Execute Gemini CLI for comprehensive code review, plan analysis, or large-context processing tasks. Ask user for model selection via AskUserQuestion. Choose approval mode based on execution context (yolo for background, default for interactive terminal only). Load CLI reference for detailed command patterns, troubleshooting, and use cases.
 
-## Constraints
+## Operating notes
 
-- NEVER use `--approval-mode default` in background or non-interactive shells (Claude Code tool calls). It hangs indefinitely waiting for user input.
-- ALWAYS use `--approval-mode yolo` for automated/background tasks or wrap with timeout: `timeout 300 gemini ...`
-- Ask user for model selection via AskUserQuestion before running commands.
-- After Gemini completes, inform user they can start a new session for follow-up analysis.
+- In background or non-interactive shells (Claude Code tool calls), don't use `--approval-mode default` — it hangs indefinitely waiting for user input. Use `--approval-mode yolo` for automated/background tasks, or wrap the call with `timeout 300 gemini ...` as a safety net.
+- Ask the user for model selection via `AskUserQuestion` before running commands.
+- After Gemini completes, tell the user they can start a new session for follow-up analysis.
 
 ## Model Selection (fallback — prefer registry)
 

--- a/skills/gemini/references/gemini-cli-reference.md
+++ b/skills/gemini/references/gemini-cli-reference.md
@@ -114,10 +114,9 @@ ps aux | grep gemini | grep -v grep
 ```
 
 ### Prevention
-- **ALWAYS use `--approval-mode yolo` for background/automated tasks**
-- Add timeout wrapper for safety: `timeout 300 gemini ...`
-- Never use `--approval-mode default` in non-interactive shells
-- Monitor first run with `ps` to ensure process completes
+- Use `--approval-mode yolo` for background/automated tasks — `default` hangs waiting for user input in non-interactive shells.
+- Wrap with `timeout 300 gemini ...` as a safety net in case the process hangs on something else.
+- Monitor the first run with `ps` to confirm it completes.
 
 ## Tips for Large Context Processing
 

--- a/skills/judgment-eval/SKILL.md
+++ b/skills/judgment-eval/SKILL.md
@@ -5,120 +5,90 @@ description: Evaluates agent judgment quality through scenario-based testing in-
 
 # Judgment Evaluation Skill
 
+## Role
+
+You generate scenario-based tests from an agent, skill, or command definition, then guide an interactive evaluation to surface where the prompt's judgment holds up and where it breaks. The output is a diagnostic report that identifies specific prompt improvements — not a pass/fail grade.
+
 ## Priorities
 
-```
 Realism (scenarios must be plausible) > Diagnostic Value (reveals actual judgment gaps) > Coverage (test multiple dimensions)
-```
 
-**Reasoning**: Unrealistic scenarios produce false signals. Diagnostic value ensures we learn from failures. Coverage prevents overfitting to a single dimension.
+Unrealistic scenarios produce false signals. Diagnostic value is why the skill exists — if we don't learn from failures, the evaluation was decoration. Coverage prevents overfitting to a single dimension.
 
-## Goal
+## Effort
 
-Generate scenario-based tests from an agent definition or system prompt, then guide interactive evaluation to identify judgment strengths, weaknesses, and prompt improvement opportunities.
+Run at `high` thinking effort. Generating scenarios that probe judgment (not just surface behavior) needs multi-step reasoning about what the prompt claims to value vs. where those claims might collide.
 
-## Constraints
+## Scope
 
-**Interactive Evaluation Only**: This skill guides manual evaluation in-conversation. Present scenarios one at a time to Claude, evaluate responses against the agent definition, then move to the next scenario. Do NOT attempt automated execution or batch processing.
-
-**Scenario Realism**: Every scenario must be plausible in actual usage. Avoid contrived corner cases that would never occur in practice.
-
-**Grounded in Agent Definition**: Generate scenarios by analyzing the agent's stated priorities, constraints, and judgment areas. Test what the agent claims to value, not generic "good judgment."
-
-**No External Dependencies**: All evaluation happens in-conversation using Read, reasoning, and response analysis. No external tools, APIs, or execution environments.
-
-**Diagnostic Focus**: When judgment fails, identify the root cause in the prompt (ambiguous priority, missing constraint, unclear scope) and suggest specific improvements.
+- **Interactive, not automated.** Scenarios are presented one at a time; the user brings Claude's responses back for evaluation. No test harness, no batch execution.
+- **In-conversation only.** No external tools, APIs, or execution environments — everything runs via Read + reasoning.
+- **Grounded in the definition.** Test what the prompt actually claims to value. Generic "good judgment" tests produce generic findings.
+- **Diagnostic, not pass/fail.** The goal is to find prompt improvements, not to grade the agent.
 
 ## Workflow
 
 ### 1. Intake
 
-Accept agent definition or system prompt via `$ARGUMENTS`:
-- File path: Read the file to extract the agent definition
-- Pasted text: Parse directly
+`$ARGUMENTS` accepts a file path or pasted text. File path → Read the file; pasted text → parse directly.
 
 Extract:
-- **Stated priorities**: What the agent claims to optimize for
-- **Hard constraints**: Non-negotiable rules (e.g., "Never commit without explicit request")
-- **Judgment areas**: Domains where the agent must make decisions (e.g., "when to ask vs proceed")
-- **Scope boundaries**: What the agent is responsible for vs not
+- **Stated priorities** — what the agent claims to optimize for.
+- **Hard constraints** — non-negotiable rules (e.g., "never commit without explicit request").
+- **Judgment areas** — domains where the agent must decide (e.g., "when to ask vs proceed").
+- **Scope boundaries** — what the agent is responsible for vs. not.
 
-### 2. Analyze
+### 2. Dimension analysis
 
-Identify dimensions of judgment to test:
-- **Priority conflicts**: Where two stated priorities might compete
-- **Scope ambiguity**: Tasks that fall between defined responsibilities
-- **Constraint edge cases**: Situations where constraints might contradict
-- **Escalation points**: When the agent should stop vs proceed
-- **Proportionality**: Whether response scale matches issue severity
+Identify which kinds of judgment are worth probing on this definition:
+- **Priority conflicts** — where two stated priorities might compete.
+- **Scope ambiguity** — tasks that fall between defined responsibilities.
+- **Constraint edge cases** — situations where constraints might contradict each other.
+- **Escalation points** — when to stop and ask vs. proceed.
+- **Proportionality** — whether response scale matches issue severity.
 
-### 3. Generate Scenarios
+Not every definition needs every dimension. Pick the ones the prompt's surface area actually exposes.
 
-For each dimension, create 2-3 scenarios following patterns from `references/scenario-patterns.md`:
+### 3. Generate scenarios
 
-**Priority Conflicts**: Present situations where two declared priorities compete directly. Force the agent to choose or reconcile.
+For each relevant dimension, create 2–3 scenarios drawing from patterns in `references/scenario-patterns.md`:
 
-**Ambiguous Scope**: Tasks that fall into gray areas of the agent's defined responsibilities.
+- **Priority conflicts** — two declared priorities compete directly; force the agent to choose or reconcile.
+- **Ambiguous scope** — tasks in the gray areas of defined responsibilities.
+- **Missing context** — critical information absent, testing ask-vs-guess.
+- **Contradictory instructions** — two constraints point opposite directions.
+- **Edge cases outside training** — novel situations the author didn't anticipate.
+- **Escalation judgment** — when to stop and ask vs. proceed with best guess.
+- **Proportionality** — does response scale match severity?
 
-**Missing Context**: Critical information is absent, testing whether the agent asks vs guesses.
+Every scenario must be plausible in actual usage. Contrived corner cases that would never occur produce false failure signals.
 
-**Contradictory Instructions**: Two constraints point in opposite directions.
-
-**Edge Cases Outside Training**: Novel situations the prompt author didn't anticipate.
-
-**Escalation Judgment**: When to stop and ask vs proceed with best guess.
-
-**Proportionality**: Does response scale match the issue's severity?
-
-### 4. Interactive Evaluation
+### 4. Interactive evaluation (find stage)
 
 For each scenario:
 
-1. **Present**: Show the scenario to the user. Ask them to present it to Claude using the agent definition as context.
+1. Present the scenario. Ask the user to run it against Claude with the agent definition as context.
+2. Capture Claude's response.
+3. Evaluate on four axes:
+   - **Priority alignment** — did the response honor stated priorities?
+   - **Constraint adherence** — were hard constraints followed?
+   - **Judgment quality** — was the decision reasonable given available information?
+   - **Escalation appropriateness** — did the agent ask when it should have, or proceed when justified?
+4. Classify: `Good Judgment` / `Surprising Judgment` / `Failed Judgment`.
+5. Move on.
 
-2. **Capture Response**: Have the user share Claude's response.
+**Find-stage discipline.** Record every observation with confidence attached, even borderline ones. Don't suppress surprising-but-defensible behaviors as "not a real failure" — they may reveal prompt gaps downstream. Filtering happens in the report, not here.
 
-3. **Evaluate Against Agent Definition**: Assess the response on:
-   - **Priority Alignment**: Did the response honor stated priorities?
-   - **Constraint Adherence**: Were hard constraints followed?
-   - **Judgment Quality**: Was the decision reasonable given available information?
-   - **Escalation Appropriateness**: Did the agent ask when it should have, or proceed when justified?
+### 5. Report (filter stage)
 
-4. **Classify**: Tag the response as:
-   - **Good Judgment**: Handled well with sound reasoning
-   - **Surprising Judgment**: Unexpected but defensible
-   - **Failed Judgment**: Violated stated priorities or constraints
+Consolidate findings:
 
-5. **Move to Next**: Proceed to the next scenario.
+- **Good Judgment.** Scenarios handled well. What reasoning worked. Which prompt elements enabled it.
+- **Surprising Judgment.** Unexpected but defensible. What priorities the agent implicitly chose. Whether that reveals a prompt gap or acceptable flexibility.
+- **Failed Judgment.** Priority or constraint violations. Root cause in the prompt (ambiguity, missing constraint, unclear priority). Whether failures cluster around a specific dimension.
+- **Suggestions.** Specific prompt edits tied to observed failure patterns — priority clarifications, constraints to add, scope boundaries to sharpen.
 
-### 5. Report
-
-After all scenarios, summarize findings:
-
-**Good Judgment**:
-- Scenarios handled well
-- What reasoning patterns worked
-- Why the agent succeeded (which prompt elements enabled this)
-
-**Surprising Judgment**:
-- Unexpected but defensible responses
-- What priorities the agent implicitly prioritized
-- Whether this reveals a prompt gap or acceptable flexibility
-
-**Failed Judgment**:
-- Responses that violated stated priorities/constraints
-- Root cause in the prompt (ambiguity, missing constraint, unclear priority)
-- Pattern analysis (do failures cluster around a specific dimension?)
-
-**Suggestions**:
-- Specific prompt improvements based on failure patterns
-- Priority clarifications needed
-- Constraints to add
-- Scope boundaries to sharpen
-
-## Output
-
-**Format**: Markdown report with sections:
+## Output format
 
 ```markdown
 # Judgment Evaluation Report
@@ -129,13 +99,13 @@ After all scenarios, summarize findings:
 
 ## Summary
 
-[1-2 sentences on overall judgment quality]
+[1–2 sentences on overall judgment quality]
 
 ## Good Judgment (X scenarios)
 
 ### Scenario: [name]
 **Response**: [brief summary]
-**Why it worked**: [reasoning about what prompt elements enabled this]
+**Why it worked**: [which prompt elements enabled this]
 
 ## Surprising Judgment (X scenarios)
 
@@ -152,7 +122,7 @@ After all scenarios, summarize findings:
 
 ## Patterns
 
-[Analysis of failure clusters and success patterns]
+[Failure clusters and success patterns]
 
 ## Suggested Improvements
 
@@ -161,25 +131,14 @@ After all scenarios, summarize findings:
 3. **[Priority Clarification]**: [How to resolve observed conflicts]
 ```
 
-## References
-
-- `references/scenario-patterns.md` - Catalog of scenario types with templates and evaluation criteria
-
-## Arguments
-
-`$ARGUMENTS` accepts:
-- **File path**: Path to agent definition (*.md file with frontmatter or system prompt)
-- **Pasted text**: Agent definition text directly
-
-If file path, Read the file. If pasted text, parse directly.
-
-## Example Usage
+## Example usage
 
 ```bash
 /judgment-eval ~/.claude/plugins/sdlc-plugin/agents/task-implementer.md
 ```
 
 Or with pasted text:
+
 ```bash
 /judgment-eval """
 You are a task implementer agent.
@@ -188,15 +147,21 @@ You are a task implementer agent.
 Spec compliance > Working code > Clean code
 
 ## Constraints
-- ONLY implement what the task requires
+- Only implement what the task requires
 - Ask when unsure using QUESTION/CONTEXT/OPTIONS
 ...
 """
 ```
 
+## References
+
+- `references/scenario-patterns.md` — catalog of scenario types with templates and evaluation criteria.
+
+## Arguments
+
+`$ARGUMENTS` — file path to an agent/skill/command definition, or the definition text pasted directly.
+
 ## Notes
 
-- **No automation**: This skill does NOT execute scenarios in a test harness. It guides interactive evaluation.
-- **Conversation-based**: Present scenarios to Claude manually, capture responses, evaluate in-conversation.
-- **Diagnostic, not pass/fail**: Goal is to identify prompt improvement opportunities, not to "grade" the agent.
-- **Iterative**: Run multiple rounds as the prompt evolves to measure improvement.
+- Run this iteratively. As the prompt evolves, re-evaluate to measure improvement against the previous findings.
+- Classifications aren't grades — they're diagnostic signal. A surprising response that reveals a prompt gap is more valuable than five successful passes.

--- a/skills/system-prompt-clinic/SKILL.md
+++ b/skills/system-prompt-clinic/SKILL.md
@@ -7,47 +7,41 @@ model: sonnet
 
 # System Prompt Clinic
 
+## Role
+
+You transform rule-based system prompts into reasoning-based equivalents that hold up on edge cases. "Reasoning-based" means the prompt trusts the model's judgment, explains *why* behind constraints so the model can generalize, and preserves only the invariants that genuinely need preserving (safety, format contracts, tool boundaries). The output is a clean rewrite plus diagnostic notes explaining what changed and why.
+
 ## Priorities
 
-```
 Accuracy (diagnose correctly) > Actionability (transform usefully) > Brevity (don't bloat the prompt)
-```
 
-Transformation should improve robustness without adding ceremony. The transformed prompt should be MORE effective at handling edge cases, not just longer.
+The transformed prompt should be more effective at handling edge cases, not just longer. If the rewrite is longer without being better, it isn't done.
 
-## Goal
+## Canonical references
 
-Transform rule-based system prompts into reasoning-based equivalents that:
-1. Trust the model's judgment while providing clear principles
-2. Handle edge cases through generalization, not enumeration
-3. Explain WHY behind constraints, enabling adaptation to novel situations
-4. Preserve necessary invariants (safety, format contracts, tool boundaries)
+When transforming prompts in this workspace, align output with:
+- `OPUS_4_7_PROMPTING.md` at the sdlc-plugin root — the 12 principles, the breaking-change checklist, and the before/after examples. Find it via `Glob(pattern: "**/sdlc/**/OPUS_4_7_PROMPTING.md", path: "~/.claude/plugins")`.
+- `references/transformation-patterns.md` — the 6 core transformation patterns, the scoring rubric, anti-patterns, and Constitutional AI citations.
+
+Read `transformation-patterns.md` before starting. When the user asks about a pattern or principle, cite it.
 
 ## Input
 
-User provides an existing system prompt via:
-- Direct paste in conversation
-- $ARGUMENTS placeholder
-- File path to read
+A system prompt via pasted text, `$ARGUMENTS`, or a file path. If it's a path, read the file first. Confirm receipt with a one-line summary (length, apparent structure).
 
 ## Workflow
 
-### 1. Intake
+### 1. Diagnose
 
-Accept the system prompt. If it's a file path, read it first. Confirm receipt with a brief summary of what you see (length, apparent structure).
+Analyze the prompt section-by-section using the scoring rubric in `references/transformation-patterns.md`. Each dimension scores 0–5:
 
-### 2. Diagnose
+- **Constraint style** — "Never/Always/Must" without reasoning (0) → principles with context (5).
+- **Workflow style** — rigid numbered steps (0) → outcome-driven with adaptation (5).
+- **Format style** — fill-in-the-blank templates (0) → judgment criteria (5).
+- **Trust level** — prescribes every detail (0) → trusts judgment, provides principles (5).
+- **Edge-case handling** — fails silently on novel cases (0) → principles that generalize (5).
 
-Analyze the prompt section-by-section using the scoring rubric from `references/transformation-patterns.md`:
-
-**Scoring Dimensions** (0-5 scale for each):
-- **Constraint Style**: "Never/Always/Must" without reasoning (0) → Principles with context (5)
-- **Workflow Style**: Rigid numbered steps (0) → Outcome-driven with adaptation (5)
-- **Format Style**: Fill-in-the-blank templates (0) → Judgment criteria (5)
-- **Trust Level**: Prescribes every detail (0) → Trusts judgment, provides principles (5)
-- **Edge Case Handling**: Fails silently on novel cases (0) → Principles that generalize (5)
-
-**Output for this step**: Present a section-by-section diagnosis:
+For each section, present:
 ```
 Section: [Name or first line]
 Average Score: X.X / 5.0
@@ -55,24 +49,14 @@ Classification: Rule-based / Hybrid / Reasoning-based
 Key Issues: [What makes it brittle or rigid]
 ```
 
-Focus on sections averaging < 3.0 that need transformation. Note sections averaging > 4.0 that are already reasoning-based.
+Focus transformation on sections averaging < 3.0. Flag sections averaging > 4.0 as already-good so you don't degrade them.
 
-### 3. Transform
+### 2. Transform
 
-For each section that needs transformation, apply patterns from `references/transformation-patterns.md`:
+For each section that needs it, pick a pattern from `references/transformation-patterns.md` (bare rules → rules with reasoning, procedure → outcome-driven, template → judgment criteria, etc.) and apply it. Then explain which edge cases the rewrite now handles.
 
-1. **Identify the pattern**: Which transformation pattern applies? (Bare rules → Rules with reasoning, Procedures → Outcome-driven, Templates → Judgment criteria, etc.)
-2. **Apply the transformation**: Rewrite using the pattern
-3. **Explain WHY**: What edge cases does the transformed version handle better?
-4. **Check for bloat**: Is the new version meaningfully better, or just longer? If it's just longer, tighten it.
+Present side-by-side:
 
-**Critical constraints**:
-- DO NOT transform safety constraints, format contracts, or tool boundaries
-- DO NOT add philosophical bloat—reasoning should be concise
-- DO preserve any machine-readable format requirements
-- DO explain the transformation's benefit for each section
-
-**Output for this step**: Present side-by-side before/after for each transformed section:
 ```
 ### Section: [Name]
 
@@ -86,11 +70,10 @@ For each section that needs transformation, apply patterns from `references/tran
 [Specific edge cases now handled, principle now enabled]
 ```
 
-### 4. Test
+### 3. Test
 
-Generate 2-3 edge-case scenarios that demonstrate the improvement:
+Generate 2–3 realistic edge-case scenarios that demonstrate the improvement:
 
-**Format**:
 ```
 ### Scenario: [Brief description]
 
@@ -101,87 +84,83 @@ Generate 2-3 edge-case scenarios that demonstrate the improvement:
 [Better outcome: model uses judgment, applies principle, adapts to context]
 ```
 
-Choose scenarios that are REALISTIC (not contrived) and showcase the value of reasoning over rules.
+Scenarios must be plausible in actual usage. Contrived corner cases produce false signal.
 
-### 5. Output
+### 4. Output
 
-Present the complete transformed prompt with:
+Deliver:
 
-1. **Summary**: High-level changes made (e.g., "Converted 4 rule-based sections, preserved 2 safety constraints, reduced 3 lists to principles")
-2. **Section-by-section transformations**: Before/after with explanations (from step 3)
-3. **Test scenarios**: Edge cases demonstrating improvement (from step 4)
-4. **Full transformed prompt**: Clean, ready-to-use version with all changes applied
+1. **Summary** — high-level changes ("converted 4 rule-based sections, preserved 2 safety constraints, reduced 3 lists to principles").
+2. **Section-by-section transformations** — the before/after blocks from step 2.
+3. **Test scenarios** — from step 3.
+4. **Full transformed prompt** — clean, ready to paste.
 
-Ask the user: "Would you like me to explain any transformation in more detail, or test additional edge cases?"
+Close with: `"Want me to explain any transformation in more detail, or test additional edge cases?"`
 
-## Constraints
+## What to preserve
 
-### Practice What You Preach
+Not every rule is a candidate for transformation. Three classes stay as-is:
 
-This skill itself must be reasoning-based:
-- Trust the model to identify rule patterns (don't enumerate every possible rule format)
-- Provide judgment criteria for diagnosis (not exhaustive checklists)
-- Explain WHY each transformation improves robustness
-- Handle novel prompt structures by applying principles, not pattern-matching
+- **Safety** — e.g., "never execute `rm -rf` without confirmation." Hard safety invariants; loosening them isn't an improvement.
+- **Format contracts** — e.g., "output must be valid JSON with keys `{x, y, z}`." Machine-readable contracts; downstream consumers depend on the shape.
+- **Tool boundaries** — e.g., "use Read for files, not cat." System-enforced; restating is fine.
 
-### Preserve Necessary Rules
+These aren't micromanagement. They encode invariants the surrounding system relies on. Leave them untouched; note them in the summary as preserved.
 
-Do NOT weaken genuinely necessary constraints:
-- **Safety**: "Never execute rm -rf without confirmation" → KEEP (hard safety)
-- **Format contracts**: "Output must be valid JSON with keys {x, y, z}" → KEEP (machine-readable contract)
-- **Tool boundaries**: "Use Read tool for files, not cat" → KEEP (enforced by system)
+## Avoid bloat
 
-These are not micromanagement. They enforce invariants.
+Reasoning should be concise. The clinic's own scoring will mark bloat as a regression, not an improvement.
 
-### Avoid Bloat
+- ❌ "Never use emojis" → 3 paragraphs on professionalism and cultural context.
+- ✅ "Never use emojis" → "Avoid emojis unless explicitly requested — they read as unprofessional in technical contexts."
 
-Reasoning should be CONCISE. Compare:
-- **Bad**: "Never use emojis" → 3 paragraphs about professionalism and cultural context
-- **Good**: "Never use emojis" → "Avoid emojis unless explicitly requested, as they can feel unprofessional in technical contexts"
+If the rewrite adds words without adding actionable value, tighten it.
 
-If reasoning doesn't add actionable value, don't add it.
+## When to ask instead of guess
 
-### Trust the User
+Domain constraints aren't always visible from the prompt text. Ask when it matters:
 
-If the user's prompt has unusual structure or domain-specific rules you don't understand, ASK:
-- "I see this section enforces X. Is this a hard business rule, or could it use more flexibility?"
-- "This template looks rigid, but if it's matching a required output format (e.g., API contract), I'll preserve it. Should I?"
+- "This section enforces X. Is that a hard business rule, or could it use more flexibility?"
+- "This template looks rigid, but if it's matching a required output format (e.g., API contract), I'll preserve it — which is it?"
 
 Don't guess about domain constraints.
 
-## References
+## Opus 4.7 alignment
 
-Read `references/transformation-patterns.md` before starting. This contains:
-- The 6 core transformation patterns with before/after examples
-- The scoring rubric for diagnosis
-- Anti-patterns to avoid
-- Constitutional AI quotes explaining WHY reasoning-based prompts work better
+When the target environment is Claude Opus 4.7 (most prompts in this workspace), also scrub for the breaking changes listed in `OPUS_4_7_PROMPTING.md`:
 
-If the user asks about a pattern or principle, reference this document.
+- `temperature`, `top_p`, `top_k` references in SDK calls (all return 400 on 4.7).
+- `budget_tokens` (removed — use `effort` instead).
+- Assistant-message prefill (returns 400 — replace with a "respond directly, no preamble" line in the system prompt).
+- Hardcoded model IDs (prefer registry-resolved aliases `opus` / `sonnet` / `haiku`).
+- "Think step by step" / "take your time" compensation phrases (obsolete — raise `effort` if depth is needed).
+- Hardcoded `max_tokens` budgets (4.7 tokenizer is 1x–1.35x more tokens per unit text).
 
-## Example Usage
+Report any of these in the diagnosis; they're not transformations so much as flagged cleanups.
+
+## Practice what you preach
+
+This skill itself is reasoning-based. Trust the model to identify rule patterns rather than enumerating every possible rule format. Provide judgment criteria for diagnosis rather than exhaustive checklists. Handle novel prompt structures by applying principles, not pattern-matching. The skill is its own first test case.
+
+## Example usage
 
 **User**: `/system-prompt-clinic "Never use emojis. Never apologize. Always use TypeScript. When committing: 1) run git status, 2) run git diff, 3) add files, 4) commit."`
 
 **Agent**:
-1. **Diagnosis**: 4 sections, all rule-based (avg score 1.5/5). Issues: bare rules, rigid procedure, no edge case handling.
-2. **Transformations**: Apply Pattern 1 (bare rules → reasoning) and Pattern 2 (procedure → outcome-driven).
-3. **Test Scenario**: "User asks for a Python script" → Original: Fails (Always TypeScript). Transformed: Asks for approval (reasoning explains when Python is appropriate).
-4. **Output**: Transformed prompt with 3 improvements, 1 test scenario, ready to use.
+1. **Diagnosis**: 4 sections, all rule-based (avg 1.5/5). Bare rules, rigid procedure, no edge-case handling.
+2. **Transformations**: Pattern 1 (bare rules → reasoning) for the first three; Pattern 2 (procedure → outcome-driven) for the commit flow.
+3. **Test scenario**: "User asks for a Python script." Original fails ("always TypeScript"). Transformed asks whether Python is acceptable and explains when it is.
+4. **Output**: Transformed prompt, 3 before/after blocks, 1 test scenario.
 
-## Edge Case Guidance
+## Edge-case guidance
 
-### If the prompt is already reasoning-based
-Acknowledge this: "This prompt is already well-structured with reasoning and trust. I found [X] sections that could be tightened, but overall it's Constitutional-aligned."
+**Prompt is already reasoning-based.** Say so: "This prompt is already well-structured with reasoning and trust. I found [X] sections that could be tightened, but overall it's Constitutional-aligned."
 
-### If the prompt is mixed (some rules, some reasoning)
-Focus on the rule-based sections. Preserve the good parts: "Sections 1, 3, 5 are already reasoning-based. I'll transform sections 2, 4, 6."
+**Mixed prompt (some rules, some reasoning).** Focus on the rule-based sections; keep the good ones intact: "Sections 1, 3, 5 are already reasoning-based. I'll transform sections 2, 4, 6."
 
-### If you're unsure whether a constraint is necessary
-Ask: "I see 'Must use format X'. Is this a hard requirement (e.g., API contract), or could it be more flexible?"
+**Unsure whether a constraint is necessary.** Ask before transforming. See "When to ask instead of guess" above.
 
-### If the transformed version feels too long
-Revisit: "The transformed version is 30% longer. Let me tighten the reasoning to preserve concision."
+**Transformed version feels too long.** Tighten the reasoning; the goal is robustness, not volume.
 
 ## Input
 


### PR DESCRIPTION
## Summary

Refactors sdlc-plugin prompts for Claude Opus 4.7 — the repo's prompts were tuned for 4.5/4.6 and earlier, and 4.7's literalness / reduced tool-call eagerness / removed API surface (sampling params, prefill, `budget_tokens`) means old scaffolding actively hurts output quality.

Continues the trajectory started by #57 (interview skill) and #51 (review command with adversarial probes).

## What changed

**New canonical reference**
- `OPUS_4_7_PROMPTING.md` — 12 principles (onboarding structure, explain-why, drop compensation phrases, find/filter split, etc.), breaking-change checklist, before/after examples, primary source URLs.

**Tier 1 — full rewrites** (1313 → 941 lines, -372 while *adding* reasoning)
- `commands/research-deep.md` 283 → 163 — collapsed Step 1-7 scaffolding into goal + cleanup invariant.
- `commands/implement.md` 292 → 198 — role + success criteria instead of subagent step-list; implementers trusted with TDD refs directly.
- `commands/research.md` 197 → 140 — cleaned routing; replaced `YOUR ONLY JOB` caps-wall with reasoned scope paragraph.
- `commands/plan.md` 151 → 106 — compressed Constraints block; each rule's rationale folded into its checkpoint.
- `skills/judgment-eval/SKILL.md` 202 → 167 — added find/filter discipline so 4.7 doesn't suppress surprising observations.
- `skills/system-prompt-clinic/SKILL.md` 188 → 167 — aligned with new principles doc; added 4.7 alignment section.

**Tier 2 — surgical caps-wall softening**
- `agents/research-synthesizer.md` — "NEVER organize by source LLM" rephrased with rationale.
- `references/blindspot-review-protocol.md` — IMPORTANT/CRITICAL gates get reason-attached prose.
- `skills/gemini/SKILL.md` + `gemini-cli-reference.md` — NEVER/ALWAYS on approval-mode gets hang-on-stdin explanation.

**Release**
- Version bumped `1.28.0 → 1.29.0`. CHANGELOG updated.

## Research basis

Findings sourced from:
- [What's new in Claude Opus 4.7](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7)
- [Claude Opus 4.7 migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide)
- [Anthropic prompting best practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices)
- [Claude's Constitution (Jan 2026)](https://www.anthropic.com/news/claudes-constitution)

Full URL list is in `OPUS_4_7_PROMPTING.md`.

## Out of scope

Sibling plugins (github, workflows, primitives, ts, misc) — deferred. The principles doc is written to apply workspace-wide; later PRs can refactor each plugin using it as the canonical reference.

## Test plan

- [ ] `bun run validate` passes (✅ confirmed locally: v1.29.0, all 7 commands documented)
- [ ] Behavioral spot-check: run `/research-deep` and `/implement` against small real tasks; compare tool-call density vs pre-refactor.
- [ ] Run `/judgment-eval` on each rewritten file with 3 scenarios to quantify the improvement.
- [ ] Scan for any remaining caps-walls or compensation phrases introduced during review.

## Plan

Full design context at `plans/opus-4-7-refactor.md` in this PR.