### PR TITLE
feat: add domain-model interview to /sdlc:plan (v1.30.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations for enhanced software development workflow",
   "author": {
     "name": "Ladislav Martincik",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the SDLC Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.30.0] - 2026-04-19
+
+### Added
+- `skills/domain-model/` — new skill that grills a plan's language against the target repo's `CONTEXT.md` and offers ADRs when architectural decisions meet the hard-to-reverse / surprising / real-trade-off bar. Includes `SKILL.md`, `CONTEXT-FORMAT.md`, and `ADR-FORMAT.md`. Writes files inline as decisions crystallise; stages without committing so `/sdlc:plan` step 6 can batch the commit.
+
+### Changed
+- `commands/plan.md` — added step 3.5 (domain-model interview) between research and draft. Intro now lists six checkpoints; step 6 commit list includes `CONTEXT.md` and `docs/adr/NNNN-*.md` produced during the interview. Plan draft blocks on unresolved terminology conflicts until addressed.
+
 ## [1.29.0] - 2026-04-18
 
 ### Added

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -14,7 +14,7 @@ Completeness (root cause addressed) > Minimality (surgical changes) > Clarity (r
 
 ## Workflow
 
-The flow is five checkpoints. Each exists because skipping it reliably produces worse plans: scope challenge stops duplicate work, interview surfaces ambiguity before it becomes rework, codebase research prevents designs that ignore what already exists, multi-LLM review catches blind spots one model misses, finalization creates the paper trail that lets implementation start.
+The flow is six checkpoints. Each exists because skipping it reliably produces worse plans: scope challenge stops duplicate work, interview surfaces ambiguity before it becomes rework, codebase research prevents designs that ignore what already exists, domain-model alignment keeps language and architecture consistent with documented decisions, multi-LLM review catches blind spots one model misses, finalization creates the paper trail that lets implementation start.
 
 ### 1. Scope challenge
 
@@ -49,6 +49,20 @@ After exploration, produce a **"What Already Exists"** summary before authoring 
 - For each: REUSE, EXTEND, or REPLACE, with a one-line justification.
 
 This prevents designing solutions that duplicate or conflict with existing code.
+
+### 3.5. Domain-model interview
+
+Find and read the domain-model protocol:
+- `Glob(pattern: "**/sdlc/**/skills/domain-model/SKILL.md", path: "~/.claude/plugins")`
+
+Run it with the user's task plus the "What Already Exists" summary from step 3 as context. The skill grills the plan's language against the target repo's `CONTEXT.md` (creating one lazily if absent), surfaces conflicts between the plan's vocabulary and documented terms, and offers ADRs when architectural decisions meet the 3-criteria bar (hard to reverse, surprising without context, real trade-off).
+
+Behaviour:
+- Writes to `CONTEXT.md` and `docs/adr/NNNN-slug.md` inline as terms resolve and ADRs are confirmed. Files are **staged, not committed** — step 6 batches them into the plan commit.
+- **Blocking:** if any term in the plan contradicts `CONTEXT.md`, the skill does not return control until the conflict is resolved (term redefined with rationale, plan restated in canonical vocabulary, or ambiguity recorded under "Flagged ambiguities" with a deferral note).
+- Returns a summary of resolved terms, conflicts closed, ADRs created, and any deferred ambiguities. Step 4 reads this summary into the plan's Notes & Context section before drafting.
+
+Language drift is cheap to catch here, expensive to reverse after implementation.
 
 ### 4. Draft plan
 
@@ -86,7 +100,7 @@ Run Codex and Gemini plan critics in parallel per the protocol. They catch diffe
 
 ### 6. Finalization
 
-Update frontmatter: `reviewed: true`, `reviewers: ["codex", "gemini"]`, `status: Ready for Implementation`. Commit on branch `plan/feature-name` for audit trail, then `/github:create-issue-from-plan plans/<name>.md` to make the work trackable.
+Update frontmatter: `reviewed: true`, `reviewers: ["codex", "gemini"]`, `status: Ready for Implementation`. Commit on branch `plan/feature-name` for audit trail — include the plan file plus any `CONTEXT.md` and `docs/adr/NNNN-*.md` files staged by step 3.5 so the language/architecture decisions ship with the plan. Then `/github:create-issue-from-plan plans/<name>.md` to make the work trackable.
 
 Append deferred items from the plan's "Out of Scope / Future Considerations" to `TODOS.md` in the project root (create if absent). Each entry:
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-plugin",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations",
   "private": true,
   "type": "module",

--- a/skills/domain-model/ADR-FORMAT.md
+++ b/skills/domain-model/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/skills/domain-model/CONTEXT-FORMAT.md
+++ b/skills/domain-model/CONTEXT-FORMAT.md
@@ -1,0 +1,77 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+A customer's request to purchase one or more items.
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+
+## Relationships
+
+- An **Order** produces one or more **Invoices**
+- An **Invoice** belongs to exactly one **Customer**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**, do we create the **Invoice** immediately?"
+> **Domain expert:** "No — an **Invoice** is only generated once a **Fulfillment** is confirmed."
+
+## Flagged ambiguities
+
+- "account" was used to mean both **Customer** and **User** — resolved: these are distinct concepts.
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One sentence max. Define what it IS, not what it does.
+- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+- **Write an example dialogue.** A conversation between a dev and a domain expert that demonstrates how the terms interact naturally and clarifies boundaries between related concepts.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/skills/domain-model/SKILL.md
+++ b/skills/domain-model/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: domain-model
+description: Grilling session that challenges a plan against the target repo's existing domain model, sharpens terminology, and updates CONTEXT.md + ADRs inline as decisions crystallise. Invoked by /sdlc:plan at step 3.5 to keep architecture aligned with documented language before the plan is drafted.
+disable-model-invocation: true
+model: opus
+---
+
+# Domain Model Interview
+
+## Priorities
+
+```
+Alignment > Precision > Brevity > Closure
+```
+
+## Role
+
+Act as a senior domain architect reviewing the plan's language against the target repo's documented model. Challenge every term. Force precise canonical vocabulary. Resolve ambiguity before it reaches the plan draft. Write decisions to `CONTEXT.md` and ADRs as they crystallise — do not batch.
+
+## Effort
+
+Run at `high` or `xhigh` thinking effort. Domain reasoning needs long-horizon branching to catch implicit conflicts.
+
+## Invocation Contract
+
+Invoked by `/sdlc:plan` step 3.5, after research, before plan draft.
+
+Inputs available in session context:
+- User's task from `$ARGUMENTS`
+- Research findings ("What Already Exists" summary from step 3)
+- Target repo cwd (not workspace root)
+
+Outputs:
+- CONTEXT.md (created or updated) in target repo
+- ADR files under `docs/adr/` when 3-criteria met and user confirms
+- Files are **staged, not committed** — `/sdlc:plan` step 6 batches commit with plan on `plan/feature-name` branch
+
+## Domain awareness
+
+At session start, probe the target repo for existing domain documentation.
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                  ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Inference rules:
+- `CONTEXT-MAP.md` exists → read it, infer which context the plan targets. If unclear, ask the user via `AskUserQuestion`.
+- Only root `CONTEXT.md` exists → single context.
+- Neither exists → create root `CONTEXT.md` lazily when the first term is resolved.
+
+Create `docs/adr/` lazily — only when the first ADR is approved.
+
+## Loop
+
+Every round follows the same cycle. Do not generalise from round one.
+
+1. <thinking>Identify the next unresolved domain branch. Note dependencies on branches already resolved. Ask: can the codebase, CONTEXT.md, or research findings answer this? If yes, explore with Read/Grep/Glob — do not ask the user.</thinking>
+2. Formulate **one domain question** per round. Present via `AskUserQuestion` with:
+   - Your recommendation marked `(Recommended)` plus a one-line rationale citing the language/arch tradeoff
+   - 2–3 alternatives with their tradeoffs
+   - `Not sure — you decide` escape hatch for low-stakes choices
+3. On answer: update `CONTEXT.md` inline if a term resolved. Evaluate ADR criteria (below). Descend into dependent branches. Repeat from step 1.
+4. If the codebase or CONTEXT.md is ambiguous or contradicts the plan, surface the conflict immediately. Do not fabricate.
+
+Footer every round: `Reply format: 1a 2b or defaults`
+
+## Focus areas
+
+Draw from these when picking the next branch. Follow the decision tree's dependencies — do not rotate mechanically.
+
+1. **Glossary conflict** — plan uses a term already defined differently in `CONTEXT.md`. Call it out: "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+2. **Fuzzy language** — vague or overloaded terms in the plan. Propose a precise canonical term: "You're saying 'account' — Customer or User? Those are different."
+3. **Relationship precision** — stress-test cardinality and boundaries with concrete scenarios. Invent edge cases that force precision.
+4. **Code-reality gap** — cross-ref the plan's claims against research findings. "Research says code cancels entire Orders, but the plan assumes partial cancellation — which is right?"
+5. **Architectural decisions worth an ADR** — see ADR section below.
+
+Skip anything answerable by reading the code or existing CONTEXT.md.
+
+## Conflict blocking
+
+If a term in the plan contradicts `CONTEXT.md` and the user has not resolved it, **do not return control to `/sdlc:plan`**. Block the plan draft (step 4) until every flagged conflict is either:
+
+- Resolved by updating `CONTEXT.md` (term redefined with explicit rationale), OR
+- Resolved by restating the plan's intent in the canonical vocabulary, OR
+- Recorded in `CONTEXT.md` under "Flagged ambiguities" with an explicit deferral note
+
+This is by design: language drift is cheap to catch now, expensive to reverse after implementation.
+
+## CONTEXT.md updates
+
+When a term is resolved, update `CONTEXT.md` immediately — do not batch. Follow the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+Rules:
+- One sentence definitions. Define what it IS.
+- Bold term names. Express cardinality in relationships.
+- Only project-specific domain terms — skip general programming concepts.
+- Record conflicts in "Flagged ambiguities" with the resolution.
+
+If no `CONTEXT.md` exists, create it the first time a term is resolved.
+
+## ADR offers
+
+Offer an ADR only when **all three** are true:
+
+1. **Hard to reverse** — cost of changing the decision later is meaningful.
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?".
+3. **Real trade-off** — genuine alternatives existed and one was picked for specific reasons.
+
+If any is missing, skip the ADR.
+
+When criteria are met, offer via `AskUserQuestion`:
+
+- Draft title and 1–3 sentence body
+- Options: `Create ADR (Recommended)` / `Edit draft` / `Skip`
+- On confirm: write to `docs/adr/NNNN-slug.md` using the format in [ADR-FORMAT.md](./ADR-FORMAT.md)
+- Number by scanning `docs/adr/` and incrementing the highest existing number
+
+Create `docs/adr/` lazily on first approved ADR.
+
+## File write discipline
+
+- Writes are **staged, not committed**. `/sdlc:plan` step 6 batches commit with the plan.
+- Never run git commands from this skill. Never create branches. Step 6 owns that.
+- Write to target repo cwd, not workspace root.
+
+## Completion
+
+Stop when either:
+
+- All flagged conflicts resolved AND no further unresolved domain branches, OR
+- User says "done" — in which case any unresolved conflict must be captured in `CONTEXT.md` "Flagged ambiguities" before returning control.
+
+On completion, return a short summary to `/sdlc:plan`:
+
+- Terms resolved (count + names)
+- Conflicts surfaced and how each was closed
+- ADRs created (paths)
+- Open ambiguities deferred (if any)
+
+`/sdlc:plan` step 4 reads this summary into the plan's Notes & Context section before drafting.
+
+## Topic
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary

- New `skills/domain-model/` skill grills plan language against the target repo's `CONTEXT.md` and offers ADRs when decisions meet the hard-to-reverse / surprising / real-trade-off bar.
- Wires the skill into `/sdlc:plan` as **step 3.5** (after research, before draft). Blocks plan draft on unresolved terminology conflicts.
- Step 6 finalization now batches `CONTEXT.md` and `docs/adr/NNNN-*.md` into the plan commit on `plan/feature-name`.
- Bumps plugin to **v1.30.0** (minor: new capability, backward-compat).

## Why

`/sdlc:plan` already catches intent gaps (step 2 user-requirements interview) and tech blindspots (step 5 Codex/Gemini review). Language and architecture drift between plans and documented domain decisions was the uncovered axis. Adding a dedicated DDD-flavoured interview catches vocabulary conflicts and architectural trade-offs before they cement in the plan draft — cheap here, expensive post-implementation.

## Design decisions

| Decision | Choice |
|----------|--------|
| Write timing | Inline as terms crystallise (matches upstream spec) |
| Integration | Always-on in `/sdlc:plan`, not opt-in flag |
| Conflict mode | Block plan draft until resolved |
| ADR trigger | Skill offers via `AskUserQuestion`, user confirms |
| File delivery | `SKILL.md` + `CONTEXT-FORMAT.md` + `ADR-FORMAT.md` (three files) |
| Commit strategy | Staged, batched with plan commit at step 6 |
| Workflow slot | Step 3.5 — after research (needs "What Already Exists" findings) |

## Files

- `skills/domain-model/SKILL.md` — new, `disable-model-invocation: true`
- `skills/domain-model/CONTEXT-FORMAT.md` — new
- `skills/domain-model/ADR-FORMAT.md` — new
- `commands/plan.md` — intro updated to six checkpoints, step 3.5 added, step 6 commit list extended
- `.claude-plugin/plugin.json` — version 1.29.0 → 1.30.0
- `CHANGELOG.md` — `[1.30.0] - 2026-04-19` entry

## Test plan

- [ ] Run `/sdlc:plan "add feature X"` in a repo with existing `CONTEXT.md` — verify skill loads at step 3.5 and grills language against glossary
- [ ] Run `/sdlc:plan` in a repo with no `CONTEXT.md` — verify skill creates one lazily when first term resolves
- [ ] Introduce a term in the plan conflicting with `CONTEXT.md` — verify skill blocks plan draft until resolved
- [ ] Trigger 3-criteria ADR scenario — verify skill offers ADR via `AskUserQuestion` and writes `docs/adr/NNNN-*.md` on confirm
- [ ] Complete /sdlc:plan end-to-end — verify step 6 commit includes plan + CONTEXT.md + ADRs on `plan/feature-name` branch
- [ ] Run `bun run validate` — verify plugin manifest + skill structure pass