### PR TITLE
refactor: inline rationale for submit/verify constraints (v1.31.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations for enhanced software development workflow",
   "author": {
     "name": "Ladislav Martincik",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the SDLC Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.31.0] - 2026-04-19
+
+### Changed
+- `commands/submit.md` — 9 constraint bullets now carry inline rationale (what breaks without the constraint, why it matters). Aligns with `OPUS_4_7_PROMPTING.md` Principle 2 ("explain why inline with every constraint") established by the v1.29.0 refactor. Opus 4.7 follows the spirit of a principle, not just the literal text; rules without inline why generalize poorly to edge cases the rule didn't anticipate.
+- `commands/verify.md` — 10 constraint bullets updated with inline rationale following the same Principle 2 alignment. No functional change; pure prompt-style refactor.
+
 ## [1.30.0] - 2026-04-19
 
 ### Added

--- a/commands/submit.md
+++ b/commands/submit.md
@@ -7,16 +7,16 @@ Verification > Correctness > Traceability
 Submit implemented plan as a pull request to GitHub. Ensures all changes are verified, properly committed, and linked to the original issue and plan.
 
 ## Constraints
-- Must be on a work branch, not main (check with `git branch --show-current`)
-- Verification must pass before submission (run `/verify {plan_file}` if not already done)
-- Issue number must exist in plan frontmatter (`issue: 123`)
-- Issue must exist in GitHub (verify with `gh issue view #123`)
-- All git changes must implement the plan fully
-- Production build must pass before submission
-- Precommit validations must pass
-- PR creation uses `/github:create-pr <issue_number> <plan_file_path>`
-- PR title format: `feat: #123 - Title`
-- PR body must link both the issue and plan
+
+- Must be on a work branch, not main (check with `git branch --show-current`) — submitting from main bypasses PR review and risks pushing unverified code to production.
+- Verification must pass before submission (run `/verify {plan_file}` if not already done) — untested code in a PR wastes reviewer time and moves failures downstream where they cost more to fix.
+- Issue number must exist in plan frontmatter (`issue: 123`) and the issue must exist in GitHub (verify with `gh issue view #123`) — the PR-to-issue link is the audit trail; a dangling reference breaks traceability for anyone reading the history later.
+- All git changes must implement the plan fully — partial implementations confuse reviewers about scope and leak work into future PRs that now depend on this one.
+- Production build must pass before submission — a broken build in the PR blocks CI, signals the implementation isn't done, and delays every other PR queued behind it.
+- Precommit validations must pass — skipping them pushes lint/format noise into review where humans have to catch it.
+- PR creation uses `/github:create-pr <issue_number> <plan_file_path>` — keeps title format, body structure, and issue linkage consistent across the workspace so reviewers know what to expect.
+- PR title format: `feat: #123 - Title` — conventional commit prefix lets release tooling categorize the change automatically.
+- PR body must link both the issue and plan — reviewers need the full decision trail (issue = why, plan = how) to judge whether the diff actually solves the problem.
 
 ## Plan
 $ARGUMENTS

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -7,16 +7,17 @@ Correctness > Completeness > Build Success > Code Quality
 Verify that the implementation matches the plan's intent and meets all success criteria. Check that code builds, validates, and aligns with the plan file before marking complete.
 
 ## Constraints
-- Read the plan file completely to understand all requirements
-- Check git diff origin/main...HEAD --stat for changed files summary
-- Verify each phase matches plan expectations before proceeding
-- Report mismatches using format: "Expected: [plan] / Found: [actual] / Why this matters: [explanation]"
-- Run production build to catch build-time errors
-- Run validation script if present in package.json
-- Execute repo health checker agent for success criteria
-- Stop immediately if build or validation fails
-- Read all referenced files fully without limit/offset parameters
-- Follow plan's intent while adapting to actual codebase context
+
+- Read the plan file completely to understand all requirements — partial reads miss edge cases and success criteria that the plan spent design effort on.
+- Check `git diff origin/main...HEAD --stat` for a changed-files summary — tells you the blast radius before diving into per-file verification.
+- Verify each phase matches plan expectations before proceeding — a silent mismatch in an early phase cascades into every later phase that builds on it.
+- Report mismatches using format: `Expected: [plan] / Found: [actual] / Why this matters: [explanation]` — the three-part format forces you to think through whether the mismatch is load-bearing or incidental.
+- Run the production build — catches build-time errors that dev mode hides (minification, tree-shaking, env-var resolution).
+- Run the validation script if present in `package.json` — the project's own definition of "valid" beats guessing.
+- Execute the repo health-checker agent for success criteria — a specialized agent with a narrower prompt catches what the generalist misses.
+- Stop immediately if build or validation fails — continuing verification on broken code produces noisy findings that distract from the real failure.
+- Read all referenced files fully without `limit`/`offset` parameters — partial reads are a known source of phantom bugs ("the code is missing X" when X is below the read window).
+- Follow the plan's intent while adapting to actual codebase context — the plan is a hypothesis; reality may have moved since planning, and rigid conformance to a stale plan misses the point.
 
 ## Verification Approach
 For each phase: verify correctness (right solution, fulfills plan, simplest approach), then verify quality (build succeeds, validation passes, health checks pass, code review clean). If multiple phases requested, verify continuously but pause only after the last phase.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-plugin",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Aligns `commands/submit.md` and `commands/verify.md` with `OPUS_4_7_PROMPTING.md` **Principle 2** — "explain why inline with every constraint." Opus 4.7 follows the spirit of a principle, not just the literal text; bare rules without inline rationale generalize poorly to edge cases the rule didn't anticipate.

- `submit.md` — 9 constraint bullets now carry what-breaks-without-it reasoning
- `verify.md` — 10 constraint bullets updated the same way
- Release bump v1.30.0 → v1.31.0 (minor; prompt-style change, no functional behavior change)

## Context

Triggered by an audit against the canon established in d193df1 (v1.29.0 Opus 4.7 prompt refactor). Deeper audit across all three workspace plugins (sdlc, primitives, github) found the rest already aligned — only these two command files still carried pre-4.7 rule-list style.

## Test plan

- [x] `bun run validate:versions` — passes (all sync at 1.31.0)
- [ ] Manual: run `/sdlc:submit` and `/sdlc:verify` against a recent plan; confirm no regression in behavior
- [ ] Review CHANGELOG entry renders correctly