### PR TITLE
feat: tdd preamble naming Goal-Driven Execution (v1.31.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations for enhanced software development workflow",
   "author": {
     "name": "Ladislav Martincik",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the SDLC Plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.31.1] - 2026-04-19
+
+### Added
+- `skills/tdd/SKILL.md` — "why this skill exists" preamble naming *Goal-Driven Execution* (the `karpathy-principles` skill in primitives-plugin, principle 4). Six lines, surgical insertion above the Priorities section. Cross-plugin half of FR-4 in `plans/karpathy-skills-improvements.md`. Originally landed in branch as v1.30.1 + v1.30.2; collapsed into a single v1.31.1 entry on rebase past v1.31.0.
+
+### Fixed
+- `skills/tdd/SKILL.md` preamble — uses prose name reference (`the` `karpathy-principles` `skill (primitives-plugin)`) rather than an absolute GitHub `main` URL. The URL would have pointed at a generated repo name on a mutating branch and rotted under upstream rename or re-org. Review finding (Gemini P2 in adversarial review of v1.30.1).
+
 ## [1.31.0] - 2026-04-19
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-plugin",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "description": "Comprehensive SDLC plugin with specialized agents, commands, and integrations",
   "private": true,
   "type": "module",

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -5,6 +5,12 @@ description: TDD enforcement during implementation. Reads `tdd:` setting from CL
 
 # TDD Enforcement Skill
 
+> **Why this skill exists.** This skill enforces *Goal-Driven Execution* —
+> [karpathy-principles](https://github.com/iamladi/cautious-computing-machine--primitives-plugin/blob/main/skills/karpathy-principles/SKILL.md),
+> principle 4 — at the procedural level. A failing test is the verifiable
+> definition of "not done"; a passing test is the verifiable definition of
+> "done for this slice." Without it, "done" drifts.
+
 ## Priorities
 
 Correctness > Test Coverage > Implementation Speed

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -5,11 +5,11 @@ description: TDD enforcement during implementation. Reads `tdd:` setting from CL
 
 # TDD Enforcement Skill
 
-> **Why this skill exists.** This skill enforces *Goal-Driven Execution* —
-> [karpathy-principles](https://github.com/iamladi/cautious-computing-machine--primitives-plugin/blob/main/skills/karpathy-principles/SKILL.md),
-> principle 4 — at the procedural level. A failing test is the verifiable
-> definition of "not done"; a passing test is the verifiable definition of
-> "done for this slice." Without it, "done" drifts.
+> **Why this skill exists.** This skill enforces *Goal-Driven Execution*
+> — principle 4 of the `karpathy-principles` skill (primitives-plugin) —
+> at the procedural level. A failing test is the verifiable definition of
+> "not done"; a passing test is the verifiable definition of "done for
+> this slice." Without it, "done" drifts.
 
 ## Priorities
 


### PR DESCRIPTION
## Summary

Adds a six-line "why this skill exists" preamble to `skills/tdd/SKILL.md` naming *Goal-Driven Execution* — principle 4 of the new `karpathy-principles` skill in the companion `primitives-plugin` PR. Cross-plugin half of FR-4 in `plans/karpathy-skills-improvements.md`.

Originally landed on this branch as v1.30.1 + v1.30.2. **Rebased past v1.31.0** (merged via #60 while this PR was open) and **collapsed into a single v1.31.1 release commit** so the version history stays linear.

## Why

The plan's three coordinated tracks publish a single canonical principles skill in `primitives-plugin` and cross-link the procedural skills (`de-slop`, `tdd`, `autoresearch`) so each one feels earned rather than imposed. This preamble is the `tdd` half — three sentences naming the underlying principle, then straight into the existing 4-phase workflow.

The preamble is surgical: six lines above the Priorities section. No reorganisation of the rest of the file. The 4-phase workflow, configuration handling, anti-pattern (horizontal slicing), per-cycle checklist, and pre-existing RED state handling are all unchanged.

## Changes

```diff
+ > **Why this skill exists.** This skill enforces *Goal-Driven Execution*
+ > — principle 4 of the `karpathy-principles` skill (primitives-plugin) —
+ > at the procedural level. A failing test is the verifiable definition
+ > of "not done"; a passing test is the verifiable definition of "done
+ > for this slice." Without it, "done" drifts.
```

Plus three-way version sync across `package.json`, `.claude-plugin/plugin.json`, and `CHANGELOG.md` per the plugin's release rule.

## Adversarial review fix (folded into v1.31.1)

Initial preamble used an absolute GitHub URL to `karpathy-principles/SKILL.md` on `main`:

```
https://github.com/iamladi/cautious-computing-machine--primitives-plugin/blob/main/skills/karpathy-principles/SKILL.md
```

Gemini (P2): `main` mutates; if the upstream skill is renamed/restructured the link rots silently. Repo name `cautious-computing-machine--primitives-plugin` looks generated and could change.

Fix: replaced with prose name reference (`the` `karpathy-principles` `skill (primitives-plugin)`). Same six-line preamble; no broken-link surface area; the user is expected to know `karpathy-principles` is in the sibling plugin from the prose name alone.

## Rebase history

| Original on branch | After rebase past v1.31.0 |
|---|---|
| 79014b6 chore: release v1.30.1 | ea85f5a chore: release v1.30.1 (replayed, no version-files) |
| 83e2315 fix: tdd preamble drops fragile GitHub main URL (v1.30.2) | 2079829 fix: tdd preamble drops fragile GitHub main URL (v1.30.2) (replayed) |
| — | 9523833 chore: release v1.31.1 (fresh bump on top) |

Branch is now `2 commits skill change + 1 commit version bump` past v1.31.0. The intermediate v1.30.1/v1.30.2 commits became no-op on version files; the v1.31.1 commit at the top carries the actual three-way bump.

## Test plan

- [x] `bun run validate` passes — sdlc v1.31.1
- [x] `bun run validate:versions` passes — synced across the three files
- [x] CI conflict resolved (force-pushed after rebase)
- [ ] Confirm `tdd` skill still loads and the 4-phase workflow executes unchanged when `tdd: strict` is set in CLAUDE.md (manual; reviewer responsibility)

## Companion PR

`primitives-plugin#26` — ships the canonical `karpathy-principles` skill, EXAMPLES.md extractions for three skills, and skill-authoring conventions doc. This PR depends on it for the cross-reference to be meaningful.